### PR TITLE
Add ports resources

### DIFF
--- a/commons/src/main/java/org/apache/mesos/elasticsearch/common/Configuration.java
+++ b/commons/src/main/java/org/apache/mesos/elasticsearch/common/Configuration.java
@@ -10,4 +10,15 @@ public class Configuration {
     public static final String TASK_NAME = "esdemo";
 
     public static final String DOMAIN = "mesos";
+
+    public static final int ELASTICSEARCH_CLIENT_PORT = 9200;
+
+    public static final int ELASTICSEARCH_TRANSPORT_PORT = 9300;
+
+    public static final double CPUS = 0.2;
+
+    public static final double MEM = 512;
+
+    public static final double DISK = 250;
+
 }

--- a/deploy-cloud-mesos.sh
+++ b/deploy-cloud-mesos.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+scp elasticsearch-cloud-mesos/build/docker/elasticsearch-cloud-mesos.zip master:
+ssh master "hdfs dfs -put -f elasticsearch-cloud-mesos.zip /elasticsearch"
+
+

--- a/deploy-executor.sh
+++ b/deploy-executor.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+scp executor/build/libs/elasticsearch-mesos-executor.jar master:
+ssh master "hdfs dfs -put -f elasticsearch-mesos-executor.jar /elasticsearch"
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
-scp executor/build/libs/elasticsearch-mesos-executor.jar master:
-ssh master "hdfs dfs -put -f elasticsearch-mesos-executor.jar /elasticsearch"
+gw clean build -x test
 
-scp scheduler/build/docker/elasticsearch-mesos-scheduler.jar master:
+./deploy-executor.sh &
+./deploy-cloud-mesos.sh &
 
-scp elasticsearch-cloud-mesos/build/docker/elasticsearch-cloud-mesos.zip master:
-ssh master "hdfs dfs -put -f elasticsearch-cloud-mesos.zip /elasticsearch"
+wait
 
+docker push mesos/elasticsearch-scheduler
+ssh slave1 "docker pull mesos/elasticsearch-scheduler" &
+ssh slave2 "docker pull mesos/elasticsearch-scheduler" &
+ssh slave3 "docker pull mesos/elasticsearch-scheduler" &
+
+wait
+
+cd scheduler; ./deploy-to-marathon.sh

--- a/scheduler/deploy-to-marathon.sh
+++ b/scheduler/deploy-to-marathon.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+curl -k -XDELETE -H "Content-Type: application/json" http://master:8080/v2/apps//elasticsearch-mesos-scheduler?force=true
 curl -k -XPOST -d @marathon.json -H "Content-Type: application/json" http://master:8080/v2/apps

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
@@ -34,6 +34,10 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
 
     public static final String TASK_DATE_FORMAT = "yyyyMMdd'T'HHmmss.SSS'Z'";
 
+    public static final int ELASTICSEARCH_CLIENT_PORT = 9200;
+
+    public static final int ELASTICSEARCH_TRANSPORT_PORT = 9300;
+
     Clock clock = new Clock();
 
     Set<Task> tasks = new HashSet<>();
@@ -133,13 +137,13 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
 
     private static void printUsage(Options options) {
         HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp("elasticsearch-scheduler", options);
+        formatter.printHelp(Configuration.FRAMEWORK_NAME, options);
     }
 
     @Override
     public void run() {
         LOGGER.info("Starting up...");
-        SchedulerDriver driver = new MesosSchedulerDriver(this, Protos.FrameworkInfo.newBuilder().setUser("").setName("ElasticSearch").build(), masterUrl);
+        SchedulerDriver driver = new MesosSchedulerDriver(this, Protos.FrameworkInfo.newBuilder().setUser("").setName(Configuration.FRAMEWORK_NAME).build(), masterUrl);
         driver.run();
     }
 
@@ -149,18 +153,45 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
 
         LOGGER.info("Framework registered as " + frameworkId.getValue());
 
-        Protos.Resource cpuResource = Protos.Resource.newBuilder()
-                .setName("cpus")
-                .setType(Protos.Value.Type.SCALAR)
-                .setScalar(Protos.Value.Scalar.newBuilder().setValue(1.0).build())
-                .build();
+        List<Protos.Resource> resources = buildResources();
 
         Protos.Request request = Protos.Request.newBuilder()
-                .addResources(cpuResource)
+                .addAllResources(resources)
                 .build();
 
         List<Protos.Request> requests = Collections.singletonList(request);
         driver.requestResources(requests);
+    }
+
+    private static List<Protos.Resource> buildResources() {
+        Protos.Resource cpus = Protos.Resource.newBuilder()
+                .setName("cpus")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(0.2).build())
+                .build();
+
+        Protos.Resource mem = Protos.Resource.newBuilder()
+                .setName("mem")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(512).build())
+                .build();
+
+        Protos.Resource disk = Protos.Resource.newBuilder()
+                .setName("disk")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(250).build())
+                .build();
+
+        Protos.Value.Range clientPortRange = Protos.Value.Range.newBuilder().setBegin(ELASTICSEARCH_CLIENT_PORT).setEnd(ELASTICSEARCH_CLIENT_PORT).build();
+        Protos.Value.Range transportPortRange = Protos.Value.Range.newBuilder().setBegin(ELASTICSEARCH_TRANSPORT_PORT).setEnd(ELASTICSEARCH_TRANSPORT_PORT).build();
+
+        Protos.Resource ports = Protos.Resource.newBuilder()
+                .setName("ports")
+                .setType(Protos.Value.Type.RANGES)
+                .setRanges(Protos.Value.Ranges.newBuilder().addRange(clientPortRange).addRange(transportPortRange))
+                .build();
+
+        return Arrays.asList(cpus, mem, disk, ports);
     }
 
     @Override
@@ -170,25 +201,7 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
 
     @Override
     public void resourceOffers(SchedulerDriver driver, List<Protos.Offer> offers) {
-        Protos.Resource cpus = Protos.Resource.newBuilder()
-                .setName("cpus")
-                .setType(Protos.Value.Type.SCALAR)
-                .setScalar(Protos.Value.Scalar.newBuilder().setValue(1.0).build())
-                .build();
-
-        Protos.Resource mem = Protos.Resource.newBuilder()
-                .setName("mem")
-                .setType(Protos.Value.Type.SCALAR)
-                .setScalar(Protos.Value.Scalar.newBuilder().setValue(2048).build())
-                .build();
-
-        Protos.Resource disk = Protos.Resource.newBuilder()
-                .setName("disk")
-                .setType(Protos.Value.Type.SCALAR)
-                .setScalar(Protos.Value.Scalar.newBuilder().setValue(1000).build())
-                .build();
-
-        List<Protos.Resource> resources = Arrays.asList(cpus, mem, disk);
+        List<Protos.Resource> resources = buildResources();
 
         for (Protos.Offer offer : offers) {
             if (isOfferGood(offer) && !haveEnoughNodes()) {

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
@@ -34,10 +34,6 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
 
     public static final String TASK_DATE_FORMAT = "yyyyMMdd'T'HHmmss.SSS'Z'";
 
-    public static final int ELASTICSEARCH_CLIENT_PORT = 9200;
-
-    public static final int ELASTICSEARCH_TRANSPORT_PORT = 9300;
-
     Clock clock = new Clock();
 
     Set<Task> tasks = new HashSet<>();
@@ -167,23 +163,23 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
         Protos.Resource cpus = Protos.Resource.newBuilder()
                 .setName("cpus")
                 .setType(Protos.Value.Type.SCALAR)
-                .setScalar(Protos.Value.Scalar.newBuilder().setValue(0.2).build())
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(Configuration.CPUS).build())
                 .build();
 
         Protos.Resource mem = Protos.Resource.newBuilder()
                 .setName("mem")
                 .setType(Protos.Value.Type.SCALAR)
-                .setScalar(Protos.Value.Scalar.newBuilder().setValue(512).build())
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(Configuration.MEM).build())
                 .build();
 
         Protos.Resource disk = Protos.Resource.newBuilder()
                 .setName("disk")
                 .setType(Protos.Value.Type.SCALAR)
-                .setScalar(Protos.Value.Scalar.newBuilder().setValue(250).build())
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(Configuration.DISK).build())
                 .build();
 
-        Protos.Value.Range clientPortRange = Protos.Value.Range.newBuilder().setBegin(ELASTICSEARCH_CLIENT_PORT).setEnd(ELASTICSEARCH_CLIENT_PORT).build();
-        Protos.Value.Range transportPortRange = Protos.Value.Range.newBuilder().setBegin(ELASTICSEARCH_TRANSPORT_PORT).setEnd(ELASTICSEARCH_TRANSPORT_PORT).build();
+        Protos.Value.Range clientPortRange = Protos.Value.Range.newBuilder().setBegin(Configuration.ELASTICSEARCH_CLIENT_PORT).setEnd(Configuration.ELASTICSEARCH_CLIENT_PORT).build();
+        Protos.Value.Range transportPortRange = Protos.Value.Range.newBuilder().setBegin(Configuration.ELASTICSEARCH_TRANSPORT_PORT).setEnd(Configuration.ELASTICSEARCH_TRANSPORT_PORT).build();
 
         Protos.Resource ports = Protos.Resource.newBuilder()
                 .setName("ports")

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchSchedulerTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchSchedulerTest.java
@@ -2,6 +2,7 @@ package org.apache.mesos.elasticsearch.scheduler;
 
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.elasticsearch.common.Configuration;
 import org.apache.mesos.elasticsearch.scheduler.matcher.OfferIDMatcher;
 import org.apache.mesos.elasticsearch.scheduler.matcher.RequestMatcher;
 import org.apache.mesos.elasticsearch.scheduler.matcher.TaskInfoMatcher;
@@ -69,7 +70,7 @@ public class ElasticsearchSchedulerTest {
     public void testRegistered() {
         scheduler.registered(driver, frameworkID, masterInfo);
 
-        Mockito.verify(driver).requestResources(Mockito.argThat(new RequestMatcher().cpus(1.0)));
+        Mockito.verify(driver).requestResources(Mockito.argThat(new RequestMatcher().cpus(Configuration.CPUS).mem(Configuration.MEM).disk(Configuration.DISK)));
     }
 
     @SuppressWarnings("unchecked")
@@ -81,7 +82,7 @@ public class ElasticsearchSchedulerTest {
         scheduler.resourceOffers(driver, Collections.singletonList(offer));
 
         OfferIDMatcher offerIdMatcher = new OfferIDMatcher("offer1");
-        TaskInfoMatcher taskInfoMatcher = new TaskInfoMatcher("elasticsearch_host1_20150306T102040.789Z").slaveId("slave1").cpus(1.0).mem(2048).disk(1000d);
+        TaskInfoMatcher taskInfoMatcher = new TaskInfoMatcher("elasticsearch_host1_20150306T102040.789Z").slaveId("slave1").cpus(Configuration.CPUS).mem(Configuration.MEM).disk(Configuration.DISK);
 
         Mockito.verify(driver).launchTasks((Collection<Protos.OfferID>) Matchers.argThat(org.hamcrest.Matchers.contains(offerIdMatcher)),
                 (Collection<Protos.TaskInfo>) Matchers.argThat(org.hamcrest.Matchers.contains(taskInfoMatcher)));
@@ -99,8 +100,8 @@ public class ElasticsearchSchedulerTest {
         OfferIDMatcher offerIdMatcher1 = new OfferIDMatcher("offer1");
         OfferIDMatcher offerIdMatcher2 = new OfferIDMatcher("offer2");
 
-        TaskInfoMatcher taskInfoMatcher1 = new TaskInfoMatcher("elasticsearch_host1_20150306T102040.789Z").slaveId("slave1").cpus(1.0).mem(2048).disk(1000d);
-        TaskInfoMatcher taskInfoMatcher2 = new TaskInfoMatcher("elasticsearch_host2_20150306T102040.900Z").slaveId("slave2").cpus(1.0).mem(2048).disk(1000d);
+        TaskInfoMatcher taskInfoMatcher1 = new TaskInfoMatcher("elasticsearch_host1_20150306T102040.789Z").slaveId("slave1").cpus(Configuration.CPUS).mem(Configuration.MEM).disk(Configuration.DISK);
+        TaskInfoMatcher taskInfoMatcher2 = new TaskInfoMatcher("elasticsearch_host2_20150306T102040.900Z").slaveId("slave2").cpus(Configuration.CPUS).mem(Configuration.MEM).disk(Configuration.DISK);
 
         Mockito.verify(driver).launchTasks((Collection<Protos.OfferID>) Mockito.argThat(org.hamcrest.Matchers.contains(offerIdMatcher1)), (Collection<Protos.TaskInfo>) Mockito.argThat(org.hamcrest.Matchers.contains(taskInfoMatcher1)));
         Mockito.verify(driver).launchTasks((Collection<Protos.OfferID>) Mockito.argThat(org.hamcrest.Matchers.contains(offerIdMatcher2)), (Collection<Protos.TaskInfo>) Mockito.argThat(org.hamcrest.Matchers.contains(taskInfoMatcher2)));
@@ -121,7 +122,7 @@ public class ElasticsearchSchedulerTest {
         scheduler.resourceOffers(driver, Arrays.asList(offer1, offer2));
 
         OfferIDMatcher offerIdMatcher1 = new OfferIDMatcher("offer1");
-        TaskInfoMatcher taskInfoMatcher1 = new TaskInfoMatcher("elasticsearch_host3_20150306T102040.789Z").slaveId("slave1").cpus(1.0).mem(2048).disk(1000d);
+        TaskInfoMatcher taskInfoMatcher1 = new TaskInfoMatcher("elasticsearch_host3_20150306T102040.789Z").slaveId("slave1").cpus(Configuration.CPUS).mem(Configuration.MEM).disk(Configuration.DISK);
 
         Mockito.verify(driver).launchTasks((Collection<Protos.OfferID>) Mockito.argThat(org.hamcrest.Matchers.contains(offerIdMatcher1)), (Collection<Protos.TaskInfo>) Mockito.argThat(org.hamcrest.Matchers.contains(taskInfoMatcher1)));
         Mockito.verify(driver).declineOffer(Protos.OfferID.newBuilder().setValue("offer2").build());

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/matcher/RequestMatcher.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/matcher/RequestMatcher.java
@@ -1,6 +1,7 @@
 package org.apache.mesos.elasticsearch.scheduler.matcher;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.elasticsearch.common.Configuration;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
@@ -12,6 +13,8 @@ import java.util.Collection;
 public class RequestMatcher extends BaseMatcher<Collection<Protos.Request>> {
 
     private double cpus;
+    private double mem;
+    private double disk;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -24,8 +27,32 @@ public class RequestMatcher extends BaseMatcher<Collection<Protos.Request>> {
                 .setScalar(Protos.Value.Scalar.newBuilder().setValue(cpus).build())
                 .build();
 
+        Protos.Resource memResource = Protos.Resource.newBuilder()
+                .setName("mem")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(mem).build())
+                .build();
+
+        Protos.Resource diskResource = Protos.Resource.newBuilder()
+                .setName("disk")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(disk).build())
+                .build();
+
+        Protos.Value.Range clientPortRange = Protos.Value.Range.newBuilder().setBegin(Configuration.ELASTICSEARCH_CLIENT_PORT).setEnd(Configuration.ELASTICSEARCH_CLIENT_PORT).build();
+        Protos.Value.Range transportPortRange = Protos.Value.Range.newBuilder().setBegin(Configuration.ELASTICSEARCH_TRANSPORT_PORT).setEnd(Configuration.ELASTICSEARCH_TRANSPORT_PORT).build();
+
+        Protos.Resource portsResource = Protos.Resource.newBuilder()
+                .setName("ports")
+                .setType(Protos.Value.Type.RANGES)
+                .setRanges(Protos.Value.Ranges.newBuilder().addRange(clientPortRange).addRange(transportPortRange))
+                .build();
+
         Protos.Request request = Protos.Request.newBuilder()
                 .addResources(cpuResource)
+                .addResources(memResource)
+                .addResources(diskResource)
+                .addResources(portsResource)
                 .build();
 
         return requests.contains(request);
@@ -38,6 +65,16 @@ public class RequestMatcher extends BaseMatcher<Collection<Protos.Request>> {
 
     public RequestMatcher cpus(double cpus) {
         this.cpus = cpus;
+        return this;
+    }
+
+    public RequestMatcher mem(double mem) {
+        this.mem = mem;
+        return this;
+    }
+
+    public RequestMatcher disk(double disk) {
+        this.disk = disk;
         return this;
     }
 


### PR DESCRIPTION
The scheduler did not ask for ports and therefore no SRV records were generated by Mesos DNS.

Updated deploy script and extracted a few constants.