### PR TITLE
adding condition to make it work with boot2docker and remote docker instance

### DIFF
--- a/elasticsearch-cloud-mesos/build.gradle
+++ b/elasticsearch-cloud-mesos/build.gradle
@@ -42,7 +42,11 @@ task copyZip(type: Copy, dependsOn: zip) {
 
 task buildDockerImage(type: DockerBuildImage) {
     dependsOn   copyZip
-    url = 'unix:///var/run/docker.sock'
+    if (file("/var/run/docker.sock").exists()) {
+       url = 'unix:///var/run/docker.sock'
+    } else {
+       url = "$System.env.DOCKER_HOST".replace("tcp","https")
+    }
     inputDir = file('.')
     tag = 'mesos/elasticsearch-cloud-mesos'
 }

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -43,7 +43,11 @@ task copyJar(type: Copy) {
 
 task buildDockerImage(type: DockerBuildImage) {
     dependsOn   copyJar
-    url = 'unix:///var/run/docker.sock'
+    if (file("/var/run/docker.sock").exists()){
+       url = 'unix:///var/run/docker.sock'
+    } else {
+       url = "$System.env.DOCKER_HOST".replace("tcp","https")
+    }
     inputDir = file('.')
     tag = 'mesos/elasticsearch-scheduler'
 }


### PR DESCRIPTION
I'm using `boot2docker` to spinup docker instances on OSX. This command looks for whether the `/var/run/docker.sock` exists, if so -- goes and follows default, otherwise uses the `DOCKER_HOST` environment variable with necessary modifications. This was useful to make it build out of the box easily. The user needs to have run `$(boot2docker shellinit)` as is the best practice before running the command.