### PR TITLE
Documentation and script to deploy in Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ hs_err_pid*
 
 # vagrant
 .vagrant/
+
+*.pem

--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ After the script has run now you can start the <i>scheduler</i> by SSHing into t
 
 ## How to install on Mesos from Mac
 
-If you have followed the steps described in "Full steps to build on Mac" then  to deploy execute the steps described in "How to install on Mesos" but use script file deployDcos.sh instead of deplay.sh.
+If you have followed the steps described in "Full steps to build on Mac" then  to deploy execute the following steps.
 
 > $ ./deployDcos.sh
 
-Follow the other steps described in <a href="#deploy">"How to install on Mesos"</a>.
+After the script has run now you can start the <i>scheduler</i> by SSHing into the master and running:
+
+> $ java -jar elasticsearch-mesos-scheduler.jar -m MASTER_IP:5050 -n 3 -nn MASTER_IP:8020
 
 ## Find Mesos master
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# elasticsearch
+# Elasticsearch
 *Coming soon!* Elasticsearch on Mesos
 
 # Getting Started
@@ -38,19 +38,19 @@ then run the following command to make sure that docker is running:
 	> $ systemctl restart docker
 
 and finally run gradlew build again:
-	> $ gradlew build
+	> $ ./gradlew build
 
 ## How to build
 
-> $ gradlew build
+> $ ./gradlew build
 
 Optionally run <a href="https://github.com/dougborg/gdub">gdub</a> which runs the gradle wrapper from any subdirectory.
 
 ## How to install on Mesos
 
-Add a host entry to your /etc/hosts which is called 'master' and points to your Mesos master. Now run
+Add a host entry to your /etc/hosts which is called 'master' and points to your Mesos master, see "Find Mesos master" to identify the master. Now run
 
-> $ deploy.sh
+> $ ./deploy.sh
 
 This script performs the following actions:
 
@@ -63,6 +63,22 @@ This script performs the following actions:
 After the script has run now you can start the <i>scheduler</i> by SSHing into the master and running:
 
 > $ java -jar elasticsearch-mesos-scheduler.jar -m MASTER_IP:5050 -n 3 -nn MASTER_IP:8020
+
+## Find Mesos master
+
+1. Open Mesos website
+	* Get the DCOS public DNS, 
+	* Copy it into another browser instance and
+	* Use port 5050 by adding at the end of the DNS public address :5050.
+This will show the Mesos website for your instance.
+2. Select from the Mesos website the 'Slaves' view
+3. Make node of all the 'Hosts' (slave hosts)
+4. In AWS Services select 'EC2'
+5. In the lefthand side menu select 'Instances'
+6. Find the instance with a 'Public DNS' which is not any of the ones belonging to the slaves and which belong to the DCOS installation
+	*  An instance belonging to the DCOS installation should have a 'Security groups' with a name that contains the word DCOS
+7.  The 'Public DNS' for that instance is what you need to ssh (run the deploy script)
+
 
 ## How to install on Marathon
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The use of <a href="https://github.com/mesosphere/marathon">Marathon</a> is opti
 
 The framework can be run by building the code, the docker images, transferring the code to the Mesos cluster and launching the framework <i>scheduler</i>.
 
-## Full steps to build in Mac
+## Full steps to build on Mac
 
 Actions to perform to start in Mac:
 
@@ -46,7 +46,7 @@ and finally run gradlew build again:
 
 Optionally run <a href="https://github.com/dougborg/gdub">gdub</a> which runs the gradle wrapper from any subdirectory.
 
-## How to install on Mesos
+## <a name="deploy"></a>How to install on Mesos
 
 Add a host entry to your /etc/hosts which is called 'master' and points to your Mesos master, see "Find Mesos master" to identify the master. Now run
 
@@ -64,13 +64,21 @@ After the script has run now you can start the <i>scheduler</i> by SSHing into t
 
 > $ java -jar elasticsearch-mesos-scheduler.jar -m MASTER_IP:5050 -n 3 -nn MASTER_IP:8020
 
+## How to install on Mesos from Mac
+
+If you have followed the steps described in "Full steps to build on Mac" then  to deploy execute the steps described in "How to install on Mesos" but use script file deployDcos.sh instead of deplay.sh.
+
+> $ ./deployDcos.sh
+
+Follow the other steps described in <a href="#deploy">"How to install on Mesos"</a>.
+
 ## Find Mesos master
 
 1. Open Mesos website
 	* Get the DCOS public DNS, 
 	* Copy it into another browser instance and
 	* Use port 5050 by adding at the end of the DNS public address :5050.
-This will show the Mesos website for your instance.
+This will show the Mesos website for your instance
 2. Select from the Mesos website the 'Slaves' view
 3. Make node of all the 'Hosts' (slave hosts)
 4. In AWS Services select 'EC2'

--- a/deployDcos.sh
+++ b/deployDcos.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+path='export PATH=$PATH:/opt/mesosphere/bin;'
+java_home='export JAVA_HOME=/opt/mesosphere/active/java/usr/java;'
+
+scp -i ForkIDFrankfurt.pem executor/build/libs/elasticsearch-mesos-executor.jar core@master:
+
+ssh -i ForkIDFrankfurt.pem  core@master "$path $java_home hadoop fs -mkdir hdfs://hdfs/elasticsearch-mesos"
+ssh -i ForkIDFrankfurt.pem  core@master "$path $java_home hadoop fs -put -f elasticsearch-mesos-executor.jar hdfs://hdfs/elasticsearch-mesos/elasticsearch-mesos-executor.jar"
+
+scp -i ForkIDFrankfurt.pem scheduler/build/docker/elasticsearch-mesos-scheduler.jar core@master:
+
+scp -i ForkIDFrankfurt.pem elasticsearch-cloud-mesos/build/docker/elasticsearch-cloud-mesos.zip core@master:
+ssh -i ForkIDFrankfurt.pem  core@master "$path $java_home hadoop fs -put -f elasticsearch-cloud-mesos.zip hdfs://hdfs/elasticsearch-mesos/elasticsearch-cloud-mesos.zip"
+


### PR DESCRIPTION
Includes:
- Ignore private key file (*.pem).
- Changes in the documentation to include steps to deploy in Mac
- New script to deploy in Mac. The base deploy.sh has now been divided in multiple file in the master but the new one for Mac is all in one file as the original deploy.sh. So deployDcos.sh could also be divided in multiple files. The name maybe should be deployMac.sh