### PR TITLE
Remove references to /etc/hosts entries in deploy.sh script

### DIFF
--- a/deploy-cloud-mesos.sh
+++ b/deploy-cloud-mesos.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-scp elasticsearch-cloud-mesos/build/docker/elasticsearch-cloud-mesos.zip master:
-ssh master "hdfs dfs -put -f elasticsearch-cloud-mesos.zip /elasticsearch"
-
+for master in $MASTERS;
+do
+    scp elasticsearch-cloud-mesos/build/docker/elasticsearch-cloud-mesos.zip ${master}:.
+    ssh ${master} "hdfs dfs -put -f elasticsearch-cloud-mesos.zip /elasticsearch"
+    break
+    #TODO: Make sure we stop after first sucessfull deployment
+done
 

--- a/deploy-executor.sh
+++ b/deploy-executor.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
-scp executor/build/libs/elasticsearch-mesos-executor.jar master:
-ssh master "hdfs dfs -put -f elasticsearch-mesos-executor.jar /elasticsearch"
+for master in $MASTERS;
+do
+    scp executor/build/libs/elasticsearch-mesos-executor.jar ${master}:.
+    ssh ${master} "hdfs dfs -put -f elasticsearch-mesos-executor.jar /elasticsearch"
+    break
+    #TODO: Make sure we stop after first sucessfull deployment
+done
+
+
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+for i in "$@"
+do
+case $i in
+    -m=*|--master=*)
+    CLI_MASTERS="${CLI_MASTERS} ${i#*=}"
+    shift
+    ;;
+    -s=*|--slave=*)
+    CLI_SLAVES="${CLI_SLAVES} ${i#*=}"
+    shift
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+done
+export MASTERS=${CLI_MASTERS-${MASTERS:-master}}
+export SLAVES=${CLI_SLAVES-${SLAVES:-slave1 slave2 slave3}}
+
+echo Will deploy to the following masters: $MASTERS
+echo Will deploy to the following slaves: $SLAVES
+
 gw clean build -x test
 
 ./deploy-executor.sh &
@@ -8,10 +30,11 @@ gw clean build -x test
 wait
 
 docker push mesos/elasticsearch-scheduler
-ssh slave1 "docker pull mesos/elasticsearch-scheduler" &
-ssh slave2 "docker pull mesos/elasticsearch-scheduler" &
-ssh slave3 "docker pull mesos/elasticsearch-scheduler" &
+for slave in $SLAVES;
+do
+    ssh $slave "docker pull mesos/elasticsearch-scheduler"
+done
 
 wait
 
-cd scheduler; ./deploy-to-marathon.sh
+cd scheduler; echo ./deploy-to-marathon.sh

--- a/scheduler/deploy-to-marathon.sh
+++ b/scheduler/deploy-to-marathon.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-curl -k -XDELETE -H "Content-Type: application/json" http://master:8080/v2/apps//elasticsearch-mesos-scheduler?force=true
+for master in $MASTERS;
+do
+    curl -k -XDELETE -H "Content-Type: application/json" http://${master}:8080/v2/apps//elasticsearch-mesos-scheduler?force=true
 
-sleep 2
+    sleep 2
 
-curl -k -XPOST -d @marathon.json -H "Content-Type: application/json" http://master:8080/v2/apps
+    curl -k -XPOST -d @marathon.json -H "Content-Type: application/json" http://${master}:8080/v2/apps
+    break
+done


### PR DESCRIPTION
Looks for masters/slaves defines as arguments with `--master=foo` and `--slave=bar`. Second looks up slaves defines in `MASTERS` and `SLAVES` environment variables. As fallback it will use `master` and `slave1 slave2 slave3`