### PR TITLE
Adding Zookeeper to system test

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
@@ -65,6 +65,7 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
         this.state = state;
     }
 
+    @SuppressWarnings("PMD.NPathComplexity")
     public static void main(String[] args) {
         Options options = new Options();
         options.addOption("m", "master host or IP", true, "master host or IP");
@@ -96,7 +97,15 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
             boolean useDocker = cmd.hasOption('d');
 
             LOGGER.info("Starting ElasticSearch on Mesos - [master: " + masterHost + ", numHwNodes: " + numberOfHwNodes + ", docker: " + (useDocker ? "enabled" : "disabled") + ", dns: " + dnsHost + "]");
-            ZooKeeperStateInterface zkState = new ZooKeeperStateInterfaceImpl(zkNode);
+
+            InetAddress zookeeperAddress = null;
+            zookeeperAddress = resolveHost(zookeeperAddress, zkNode);
+            if (zookeeperAddress == null) {
+                LOGGER.error("Could not resolve zookeeper host : " + zkNode);
+                System.exit(-1);
+            }
+
+            ZooKeeperStateInterface zkState = new ZooKeeperStateInterfaceImpl(zkNode + ":" + 2181);
             State state = new State(zkState);
 
             final ElasticsearchScheduler scheduler = new ElasticsearchScheduler(masterHost, dnsHost, numberOfHwNodes, useDocker, nameNode, state);
@@ -320,7 +329,7 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
         return taskInfoBuilder.build();
     }
 
-    private InetAddress resolveHost(InetAddress masterAddress, String host) {
+    private static InetAddress resolveHost(InetAddress masterAddress, String host) {
         try {
             masterAddress = InetAddress.getByName(host);
         } catch (UnknownHostException e) {
@@ -404,8 +413,6 @@ public class ElasticsearchScheduler implements Scheduler, Runnable {
             }
         }
         return true;
-
-        //TODO: return tasks.stream().map(Task::getHostname).noneMatch(Predicate.isEqual(offer.getHostname()));
     }
 
     private boolean haveEnoughNodes() {

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/State.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/State.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ExecutionException;
  * In the future, we can also persist other state information to be more resilient.
  */
 public class State {
-    private static String FRAMEWORK_ID_KEY = "frameworkId";
+    private static String FRAMEWORK_ID = "frameworkId";
     private ZooKeeperStateInterface zkState;
 
     public State(ZooKeeperStateInterface zkState) {
@@ -30,7 +30,7 @@ public class State {
      * @throws InvalidProtocolBufferException
      */
     public FrameworkID getFrameworkID() throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
-        byte[] existingFrameworkId = zkState.fetch(FRAMEWORK_ID_KEY).get().value();
+        byte[] existingFrameworkId = zkState.fetch(FRAMEWORK_ID).get().value();
         if (existingFrameworkId.length > 0) {
             return FrameworkID.parseFrom(existingFrameworkId);
         } else {
@@ -39,7 +39,7 @@ public class State {
     }
 
     public void setFrameworkId(FrameworkID frameworkId) throws InterruptedException, ExecutionException {
-        Variable value = zkState.fetch(FRAMEWORK_ID_KEY).get();
+        Variable value = zkState.fetch(FRAMEWORK_ID).get();
         value = value.mutate(frameworkId.toByteArray());
         zkState.store(value).get();
     }

--- a/system-test/src/test/resources/mesos-es/dind/Dockerfile
+++ b/system-test/src/test/resources/mesos-es/dind/Dockerfile
@@ -1,4 +1,4 @@
-FROM redjack/mesos-slave:0.21.0
+FROM mesosphere/mesos-slave:0.22.1-1.0.ubuntu1404
 
 # TODO Optimize
 

--- a/system-test/src/test/resources/mesos-es/docker-compose.yml
+++ b/system-test/src/test/resources/mesos-es/docker-compose.yml
@@ -5,13 +5,18 @@ dns:
   - slave1
   - slave2
   - slave3
+zookeeper:
+  image: jplock/zookeeper:3.4.5
+  links:
+    - mesosmaster
 mesosmaster:
-  image: redjack/mesos-master:0.21.0
+  image: mesosphere/mesos-master:0.22.1-1.0.ubuntu1404
   hostname: mesosmaster
   environment:
     - MESOS_QUORUM=1
     - MESOS_WORK_DIR=/var/lib/mesos
     - MESOS_LOG_DIR=/var/log
+    - MESOS_ZK=zk://zookeeper:2181
   volumes:
     - /var/log/mesos:/var/log/mesos
   ports:
@@ -45,10 +50,11 @@ slave3:
    - mesosmaster
 scheduler:
   image: mesos/elasticsearch-scheduler
-  command: "-d -m mesosmaster -dns dns -n 3 -nn localhost"
+  command: "-d -zk zookeeper -m mesosmaster -dns dns -n 3 -nn localhost"
   links:
    - mesosmaster
    - slave1
    - slave2
    - slave3
    - dns
+   - zookeeper


### PR DESCRIPTION
Current status:

```scheduler_1 | 2015-06-10 14:14:50,100:1(0x7f9005bbd700):ZOO_INFO@zookeeper_init@786: Initiating client connection, host=zookeeper:2181 sessionTimeout=20000 watcher=0x7f902cbbda60 sessionId=0 sessionPasswd=<null> context=0x7f8fec000b60 flags=0
scheduler_1 | 2015-06-10 14:14:50,101:1(0x7f90033b8700):ZOO_INFO@check_events@1703: initiated connection to server [172.17.0.4:2181]
zookeeper_1 | 2015-06-10 14:14:50,102 [myid:] - INFO  [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:NIOServerCnxnFactory@197] - Accepted socket connection from /172.17.0.13:45046
zookeeper_1 | 2015-06-10 14:14:50,108 [myid:] - WARN  [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:ZooKeeperServer@822] - Connection request from old client /172.17.0.13:45046; will be dropped if server is in r-o mode
zookeeper_1 | 2015-06-10 14:14:50,109 [myid:] - INFO  [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:ZooKeeperServer@868] - Client attempting to establish new session at /172.17.0.13:45046
zookeeper_1 | 2015-06-10 14:14:50,111 [myid:] - INFO  [SyncThread:0:FileTxnLog@199] - Creating new log file: log.1
zookeeper_1 | 2015-06-10 14:14:50,122 [myid:] - INFO  [SyncThread:0:ZooKeeperServer@617] - Established session 0x14dddd2c1150000 with negotiated timeout 20000 for client /172.17.0.13:45046
scheduler_1 | 2015-06-10 14:14:50,122:1(0x7f90033b8700):ZOO_INFO@check_events@1750: session establishment complete on server [172.17.0.4:2181], sessionId=0x14dddd2c1150000, negotiated timeout=20000
scheduler_1 | [INFO] 2015-06-10 14:14:50,135 class org.apache.mesos.elasticsearch.scheduler.ElasticsearchScheduler run - Starting up ...
scheduler_1 | *** Error in `java': free(): invalid pointer: 0x00007f905386b0c0 ***
scheduler_1 | #
scheduler_1 | # A fatal error has been detected by the Java Runtime Environment:```