### PR TITLE
Fix for bug 124. Added use of overlay storage driver for docker. 

### DIFF
--- a/system-test/src/test/resources/mesos-es/slave-dind/supervisor.conf
+++ b/system-test/src/test/resources/mesos-es/slave-dind/supervisor.conf
@@ -13,3 +13,4 @@ user=root
 command=/usr/local/bin/wrapdocker
 redirect_stderr=true
 stdout_logfile=/var/log/dind.log
+environment=DOCKER_DAEMON_ARGS="-s overlay"


### PR DESCRIPTION
This will only work for docker-machine based VMs and native users with kernel's versions 3.16+