### PR TITLE
WIP: First shot at integrating mini-mesos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven {
+            url "https://jitpack.io"
+        }
     }
 
     dependencies {
@@ -75,7 +78,7 @@ subprojects {
         compile 'com.google.code.gson:gson:2.3'         // marshalling between the scheduler and executor
 
 
-        testCompile 'junit:junit:4.11'
+        testCompile 'junit:junit:4.12'
         testCompile 'commons-collections:commons-collections:3.2.1'
         testCompile "org.mockito:mockito-all:1.9.5"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-version=0.1.0-SNAPSHOT
-
 org.gradle.jvmargs=-Xmx1024M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # faster builds: gradle build -x findBugsM

--- a/gradle/spock.gradle
+++ b/gradle/spock.gradle
@@ -11,11 +11,11 @@ dependencies {
 
     testCompile 'cglib:cglib-nodep:2.2.2'               // need to mock classes
 
-    // useful to mock out statics and final classes in Java.
-    testCompile "org.powermock:powermock-module-junit4:$powermockVersion"
-    testCompile "org.powermock:powermock-module-junit4-rule:$powermockVersion"
-    testCompile "org.powermock:powermock-classloading-xstream:$powermockVersion"
-    testCompile "org.powermock:powermock-api-mockito:$powermockVersion"
+//    // useful to mock out statics and final classes in Java.
+//    testCompile "org.powermock:powermock-module-junit4:$powermockVersion"
+//    testCompile "org.powermock:powermock-module-junit4-rule:$powermockVersion"
+//    testCompile "org.powermock:powermock-classloading-xstream:$powermockVersion"
+//    testCompile "org.powermock:powermock-api-mockito:$powermockVersion"
 }
 
 // for spock to live in test java tree

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -11,4 +11,6 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
 
 ADD ./build/docker/elasticsearch-mesos-scheduler.jar /tmp/elasticsearch-mesos-scheduler.jar
 
+EXPOSE 5005 8080
+
 ENTRYPOINT ["java", "-Djava.library.path=/usr/local/lib", "-jar", "/tmp/elasticsearch-mesos-scheduler.jar"]

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     compile("org.springframework.boot:spring-boot-starter-web:1.2.4.RELEASE")
     compile("org.springframework.boot:spring-boot-starter-log4j:1.2.4.RELEASE")
-    compile "commons-cli:commons-cli:1.0"
+    compile "commons-cli:commons-cli:1.3.1"
     compile "commons-io:commons-io:2.4"
     compile "log4j:log4j:1.2.17"
 
@@ -43,7 +43,7 @@ dependencies {
     compile 'org.webjars:angular-moment:0.10.1'
     compile 'org.webjars.bower:json-formatter:0.2.7'
 
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'org.hamcrest:hamcrest-core:1.3'
     testCompile 'joda-time:joda-time:2.3'
 
 }

--- a/system-test/build.gradle
+++ b/system-test/build.gradle
@@ -4,41 +4,16 @@ dependencies {
 
     compile project(':scheduler')
 
-    testCompile 'junit:junit:4.11'
+    testCompile 'junit:junit:4.12'
     testCompile 'com.github.docker-java:docker-java:1.3.0'
     testCompile 'com.mashape.unirest:unirest-java:1.4.5'
     testCompile 'com.jayway.awaitility:awaitility:1.6.3'
+    testCompile 'com.github.ContainerSolutions:mini-mesos:0.2-SNAPSHOT'
 }
 
 test {
     exclude '**/*SystemTest*'
 }
-
-task dockerComposeUp(type: Exec) {
-
-    workingDir "${project.projectDir}/src/test/resources/mesos-es"
-
-    commandLine 'docker-compose', 'up', '-d'
-
-}
-
-task dockerComposeKill(type: Exec) {
-
-    workingDir "${project.projectDir}/src/test/resources/mesos-es"
-
-    commandLine 'docker-compose', 'kill'
-
-}
-
-task dockerComposeRm(type: Exec) {
-
-    workingDir "${project.projectDir}/src/test/resources/mesos-es"
-
-    commandLine 'docker-compose', 'rm', '--force', '-v'
-
-}
-
-dockerComposeKill.finalizedBy dockerComposeRm
 
 task systemTest(type: Test) {
     include '**/*SystemTest*'
@@ -47,6 +22,3 @@ task systemTest(type: Test) {
     }
     outputs.upToDateWhen { false }
 }
-
-systemTest.dependsOn(dockerComposeUp)
-systemTest.finalizedBy dockerComposeKill

--- a/system-test/src/test/java/org/apache/mesos/elasticsearch/systemtest/DiscoverySystemTest.java
+++ b/system-test/src/test/java/org/apache/mesos/elasticsearch/systemtest/DiscoverySystemTest.java
@@ -55,6 +55,7 @@ public class DiscoverySystemTest extends TestBase {
         @Override
         public Boolean call() throws Exception {
             try {
+                //todo: get ES urls from Scheduler/tasks API
                 double nodesSlave1 = Unirest.get("http://" + ipAddress1 + ":9200/_nodes").asJson().getBody().getObject().getJSONObject("nodes").length();
                 double nodesSlave2 = Unirest.get("http://" + ipAddress2 + ":9200/_nodes").asJson().getBody().getObject().getJSONObject("nodes").length();
                 double nodesSlave3 = Unirest.get("http://" + ipAddress3 + ":9200/_nodes").asJson().getBody().getObject().getJSONObject("nodes").length();

--- a/system-test/src/test/java/org/apache/mesos/elasticsearch/systemtest/StatusApiSystemTest.java
+++ b/system-test/src/test/java/org/apache/mesos/elasticsearch/systemtest/StatusApiSystemTest.java
@@ -6,8 +6,9 @@ import com.mashape.unirest.http.Unirest;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static org.apache.mesos.elasticsearch.systemtest.SystemTestMatchers.*;
-import static org.hamcrest.Matchers.startsWith;
+import static org.apache.mesos.elasticsearch.systemtest.SystemTestMatchers.isValidAddress;
+import static org.apache.mesos.elasticsearch.systemtest.SystemTestMatchers.isValidDateTime;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -18,14 +19,15 @@ public class StatusApiSystemTest extends TestBase {
 
     @Test
     public void canGet200FromScheduler() throws Exception {
-        String schedulerIp = getSlaveIp("mesoses_scheduler_1");
-        HttpResponse<JsonNode> tasksResponse = Unirest.get("http://" + schedulerIp + ":8080/tasks").asJson();
+        String schedulerIp = getSlaveIp(schedulerId);
+        assertThat(schedulerIp, not(isEmptyOrNullString()));
+        final HttpResponse<String> tasksResponse = Unirest.get("http://" + schedulerIp + ":8080/tasks").asString();
         assertEquals(200, tasksResponse.getStatus());
     }
 
     @Test
     public void hasThreeTasksWithValidInformation() throws Exception {
-        String schedulerIp = getSlaveIp("mesoses_scheduler_1");
+        String schedulerIp = getSlaveIp(schedulerId);
         HttpResponse<JsonNode> tasksResponse = Unirest.get("http://" + schedulerIp + ":8080/tasks").asJson();
 
         assertEquals(3, tasksResponse.getBody().getArray().length());

--- a/system-test/src/test/java/org/apache/mesos/elasticsearch/systemtest/TestBase.java
+++ b/system-test/src/test/java/org/apache/mesos/elasticsearch/systemtest/TestBase.java
@@ -1,37 +1,69 @@
 package org.apache.mesos.elasticsearch.systemtest;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.core.DockerClientBuilder;
-import com.github.dockerjava.core.DockerClientConfig;
 import com.mashape.unirest.http.Unirest;
-import org.apache.http.HttpHost;
 import org.apache.log4j.Logger;
-import org.junit.Before;
+import org.apache.mesos.mini.MesosCluster;
+import org.apache.mesos.mini.mesos.MesosClusterConfig;
+import org.junit.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
 
 /**
  * Base test class for everything shared between test cases
  */
 public abstract class TestBase {
+    protected static final MesosClusterConfig config = MesosClusterConfig.builder()
+            .numberOfSlaves(3)
+            .privateRegistryPort(15000) // Currently you have to choose an available port by yourself
+            .slaveResources(new String[]{"ports(*):[9200-9200,9300-9300]", "ports(*):[9201-9201,9301-9301]", "ports(*):[9202-9202,9302-9302]"})
+            .build();
+
+    @ClassRule
+    public static MesosCluster cluster = new MesosCluster(config);
+
     private static final Logger LOGGER = Logger.getLogger(TestBase.class);
-    DockerClient docker;
+    protected static String schedulerId;
+    static DockerClient docker;
 
     protected String getSlaveIp(String slaveName) {
-
         InspectContainerResponse response = docker.inspectContainerCmd(slaveName).exec();
-
         return response.getNetworkSettings().getIpAddress();
     }
 
-    @Before
-    public void setUp() throws Exception {
-        DockerClientConfig config = DockerClientConfig.createDefaultConfigBuilder()
-                .withVersion("1.16")
-                .build();
+    @BeforeClass
+    public static void startScheduler() throws Exception {
+        docker = config.dockerClient;
 
-        docker = DockerClientBuilder.getInstance(config).build();
-        HttpHost proxy = new HttpHost(config.getUri().getHost(), 8888);
-        Unirest.setProxy(proxy);
-        Unirest.setDefaultHeader("Content-Type", "application/json");
+        final String schedulerImage = "mesos/elasticsearch-scheduler";
+
+        CreateContainerCmd createCommand = docker
+                .createContainerCmd(schedulerImage)
+                .withExtraHosts(IntStream.rangeClosed(1, config.numberOfSlaves).mapToObj(value -> "slave" + value + ":" + cluster.getMesosContainer().getMesosMasterIP()).toArray(String[]::new))
+                .withCmd("-zk", "zk://" + cluster.getMesosContainer().getMesosMasterIP() + ":2181/mesos", "-n", "3");
+
+        final CreateContainerResponse createSchedulerResponse = createCommand.exec();
+        schedulerId = createSchedulerResponse.getId();
+        assertThat(schedulerId, not(isEmptyOrNullString()));
+        docker.startContainerCmd(schedulerId).exec();
+
+        assertThat(schedulerId, not(isEmptyOrNullString()));
+        final String schedulerIp = docker.inspectContainerCmd(schedulerId).exec().getNetworkSettings().getIpAddress();
+        await().atMost(20, TimeUnit.SECONDS).until(() -> Unirest.get("http://" + schedulerIp + ":8080/tasks").asString().getStatus() == 200);
+    }
+
+
+    @AfterClass
+    public static void stopScheduler() throws Exception {
+        docker.removeContainerCmd(schedulerId).withForce().exec();
     }
 }


### PR DESCRIPTION
Make sure you build the docker image from mini-mesos, i.e.

```
docker build -t containersolutions/mesos-local src/main/resources/mesos-local
```

Still missing:

- [ ] Fixing tests in `org.apache.mesos.elasticsearch.systemtest.DiscoverySystemTest`
- [ ] Improving stability by only spinning up a mesos cluster on each test class and the scheduler on each test method.