### PR TITLE
Scheduler Search API endpoint returns "java.util.NoSuchElementException"

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Task.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Task.java
@@ -68,12 +68,7 @@ public class Task {
         String hostName = data.getProperty("hostname", "UNKNOWN");
         String ipAddress = data.getProperty("ipAddress", hostName);
         ZonedDateTime startedAt = ZonedDateTime.parse(data.getProperty("startedAt", ZonedDateTime.now().toString()));
-        Protos.TaskState taskState = null;
-        if (taskStatus == null) {
-            taskState = Protos.TaskState.TASK_STAGING;
-        } else {
-            taskState = taskStatus.getState();
-        }
+        final Protos.TaskState taskState = taskStatus == null ? Protos.TaskState.TASK_STAGING : taskStatus.getState();
         return new Task(
                 hostName,
                 taskInfo.getTaskId().getValue(),

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/controllers/SearchProxyController.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/controllers/SearchProxyController.java
@@ -1,5 +1,6 @@
 package org.apache.mesos.elasticsearch.scheduler.controllers;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -10,7 +11,6 @@ import org.apache.mesos.elasticsearch.scheduler.Task;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.*;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,11 +50,11 @@ public class SearchProxyController {
     }
 
     @RequestMapping("/_search")
-    public ResponseEntity<InputStreamResource> search(@RequestParam("q") String query, @RequestHeader(value = "X-ElasticSearch-TaskId", required = false) String elasticSearchTaskId) throws IOException {
+    public ResponseEntity<InputStreamResource> search(@RequestParam("q") String query, @RequestParam(value = "node", required = false) String elasticSearchTaskId) throws IOException {
         HttpHost httpHost;
         Collection<Task> tasks = scheduler.getTasks().values();
 
-        if (elasticSearchTaskId != null) {
+        if (StringUtils.isNotBlank(elasticSearchTaskId)) {
             httpHost = tasks.stream().filter(task -> task.getTaskId().equals(elasticSearchTaskId)).map(task -> toHttpHost(task.getClientAddress())).findAny().get();
         } else {
             httpHost = tasks.stream().skip(RandomUtils.nextInt(tasks.size())).map(task -> toHttpHost(task.getClientAddress())).findAny().get();

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/ClusterState.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/ClusterState.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.NotSerializableException;
 import java.security.InvalidParameterException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.apache.mesos.Protos.TaskID;
 
@@ -47,11 +46,9 @@ public class ClusterState {
      * @return
      */
     public Map<String, Task> getGuiTaskList() {
-        return getTaskList().stream().collect(Collectors.toMap(
-                        taskInfo -> taskInfo.getTaskId().getValue(),
-                        taskInfo -> Task.from(taskInfo, getStatus(taskInfo.getTaskId()).getStatus())
-                )
-        );
+        Map<String, Task> tasks = new HashMap<>();
+        getTaskList().forEach(taskInfo -> tasks.put(taskInfo.getTaskId().getValue(), Task.from(taskInfo, getStatus(taskInfo.getTaskId()).getStatus())));
+        return tasks;
     }
 
     /**

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/ClusterState.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/ClusterState.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.NotSerializableException;
 import java.security.InvalidParameterException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.apache.mesos.Protos.TaskID;
 
@@ -46,9 +47,11 @@ public class ClusterState {
      * @return
      */
     public Map<String, Task> getGuiTaskList() {
-        Map<String, Task> tasks = new HashMap<>();
-        getTaskList().forEach(taskInfo -> tasks.put(taskInfo.getTaskId().getValue(), Task.from(taskInfo, getStatus(taskInfo.getTaskId()).getStatus())));
-        return tasks;
+        return getTaskList().stream().collect(Collectors.toMap(
+                        taskInfo -> taskInfo.getTaskId().getValue(),
+                        taskInfo -> Task.from(taskInfo, getStatus(taskInfo.getTaskId()).getStatus())
+                )
+        );
     }
 
     /**

--- a/scheduler/src/main/resources/public/app/controllers.js
+++ b/scheduler/src/main/resources/public/app/controllers.js
@@ -255,26 +255,24 @@ controllers.controller('QueryBrowserController', function ($scope, $http, $locat
         results: null,
     };
 
-    $scope.$parent.$watch('nodes', function(value) {
-        if (value.length && $scope.query.node == '') {
-            $scope.query.node = value[0];
-        }
-    });
-
     $scope.querySubmit = function() {
-        if ($scope.query.node && $scope.query.string) {
-            $http.defaults.headers.common['X-ElasticSearch-Host'] = $scope.query.node;
-            var success = function(data) {
-                $scope.query.results = data.hits;
-            }
-            var error = function(data) {
-                if (data.hasOwnProperty('error')) {
-                    $scope.query.error = data.error;
-                } else {
-                    $scope.query.error = "Unknown error"
+        if ($scope.query.string) {
+            Search.get(
+                {
+                    q: $scope.query.string,
+                    node: $scope.query.node
+                },
+                function(data) {
+                    $scope.query.results = data.hits;
+                },
+                function(data) {
+                    if (data.hasOwnProperty('error')) {
+                        $scope.query.error = data.error;
+                    } else {
+                        $scope.query.error = "Unknown error"
+                    }
                 }
-            }
-            Search.get({q: $scope.query.string}, success, error);
+            );
         }
     };
 

--- a/scheduler/src/main/resources/public/partials/query-browser.html
+++ b/scheduler/src/main/resources/public/partials/query-browser.html
@@ -7,7 +7,9 @@
                     <input type="text" class="form-control query-string-input" ng-model="query.string" placeholder="Enter your query...">
                 </div>
                 <div class="form-group">
-                    <select class="form-control" ng-model="query.node" ng-options="node for node in nodes"></select>
+                    <select class="form-control" ng-model="query.node" ng-options="task.id as task.id for task in tasks">
+                        <option value="">Any</option>
+                    </select>
                 </div>
                 <button type="submit" class="btn btn-primary">Search</button>
                 <button type="button" class="btn btn-default" ng-click="resetQuery()">Reset</button>

--- a/system-test/src/main/java/org/apache/mesos/elasticsearch/systemtest/ElasticsearchSchedulerContainer.java
+++ b/system-test/src/main/java/org/apache/mesos/elasticsearch/systemtest/ElasticsearchSchedulerContainer.java
@@ -2,6 +2,8 @@ package org.apache.mesos.elasticsearch.systemtest;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.elasticsearch.common.cli.ElasticsearchCLIParameter;
 import org.apache.mesos.elasticsearch.common.cli.ZookeeperCLIParameter;
@@ -50,7 +52,8 @@ public class ElasticsearchSchedulerContainer extends AbstractContainer {
         return dockerClient
                 .createContainerCmd(SCHEDULER_IMAGE)
                 .withName(SCHEDULER_NAME + "_" + new SecureRandom().nextInt())
-                .withEnv("JAVA_OPTS=-Xms128m -Xmx256m")
+                .withExposedPorts(ExposedPort.tcp(5005)).withPortBindings(PortBinding.parse("5005:5005"))
+                .withEnv("JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Xms128m -Xmx256m")
                 .withExtraHosts(IntStream.rangeClosed(1, 3).mapToObj(value -> "slave" + value + ":" + mesosIp).toArray(String[]::new))
                 .withCmd(
                         ZookeeperCLIParameter.ZOOKEEPER_MESOS_URL, getZookeeperMesosUrl(),

--- a/system-test/src/main/java/org/apache/mesos/elasticsearch/systemtest/TasksResponse.java
+++ b/system-test/src/main/java/org/apache/mesos/elasticsearch/systemtest/TasksResponse.java
@@ -30,7 +30,7 @@ public class TasksResponse {
     public TasksResponse(String schedulerIpAddress, int nodesCount) {
         this.schedulerIpAddress = schedulerIpAddress;
         this.nodesCount = nodesCount;
-        await().atMost(60, TimeUnit.SECONDS).until(new TasksCall());
+        await().atMost(60, TimeUnit.SECONDS).pollDelay(1, TimeUnit.SECONDS).until(new TasksCall());
     }
 
     public TasksResponse(String schedulerIpAddress, int nodesCount, String nodesState) {

--- a/system-test/src/systemTest/java/org/apache/mesos/elasticsearch/systemtest/SearchProxySystemTest.java
+++ b/system-test/src/systemTest/java/org/apache/mesos/elasticsearch/systemtest/SearchProxySystemTest.java
@@ -1,0 +1,83 @@
+package org.apache.mesos.elasticsearch.systemtest;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.jayway.awaitility.Awaitility;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import org.apache.mesos.mini.container.AbstractContainer;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test Search Proxy controller
+ */
+public class SearchProxySystemTest extends TestBase {
+
+    private static AbstractContainer dataImporter;
+
+    private static String searchEndpoint;
+    private static List<String> slavesElasticAddresses;
+
+    @Rule
+    public TestWatcher pusherWatch = new TestWatcher() { };
+
+    @BeforeClass
+    public static void importData() throws Exception {
+        slavesElasticAddresses = new TasksResponse(getScheduler().getIpAddress(), CLUSTER.getConfig().getNumberOfSlaves()).getTasks().stream().map(jsonObject -> jsonObject.getString("http_address")).collect(toList());
+
+        dataImporter = new AbstractContainer(CLUSTER.getConfig().dockerClient) {
+            private String imageName;
+
+            @Override
+            protected void pullImage() {
+                imageName = "mwldk/shakespeare-import";
+                pullImage(imageName, "latest");
+            }
+
+            @Override
+            protected CreateContainerCmd dockerCommand() {
+                return dockerClient.createContainerCmd(imageName).withEnv("ELASTIC_SEARCH_URL=" + "http://" + slavesElasticAddresses.get(0));
+            }
+        };
+
+
+        Awaitility.await().atMost(5, TimeUnit.MINUTES).pollDelay(2, TimeUnit.SECONDS).until(() -> {
+            try {
+                return Unirest.get("http://" + slavesElasticAddresses.get(0) + "/_nodes").asJson().getBody().getObject().getJSONObject("nodes").length() == 3;
+            } catch (UnirestException e) {
+                return false;
+            }
+        });
+        final String importerId = CLUSTER.addAndStartContainer(dataImporter);
+        Awaitility.await().atMost(2, TimeUnit.MINUTES).pollDelay(1, TimeUnit.SECONDS).until(() -> !CLUSTER.getConfig().dockerClient.inspectContainerCmd(importerId).exec().getState().isRunning());
+
+        searchEndpoint = "http://" + getScheduler().getIpAddress() + ":31100/v1/es/_search";
+    }
+
+    @Test
+    public void canRetrieveSearchResultFromRandomNode() throws Exception {
+        final HttpResponse<JsonNode> response = Unirest.get(searchEndpoint).queryString("q", "love").asJson();
+        assertEquals(200, response.getStatus());
+        assertFalse(response.getBody().getObject().getBoolean("timed_out"));
+        assertEquals(10, response.getBody().getObject().getJSONObject("hits").getJSONArray("hits").length());
+    }
+
+    @Test
+    public void canRetrieveSearchResultFromParticularNode() throws Exception {
+        final HttpResponse<JsonNode> response = Unirest.get(searchEndpoint).queryString("q", "love").header("X-ElasticSearch-Host", slavesElasticAddresses.get(1)).asJson();
+        assertEquals(200, response.getStatus());
+        assertFalse(response.getBody().getObject().getBoolean("timed_out"));
+        assertEquals(10, response.getBody().getObject().getJSONObject("hits").getJSONArray("hits").length());
+    }
+}

--- a/system-test/src/systemTest/java/org/apache/mesos/elasticsearch/systemtest/SearchProxySystemTest.java
+++ b/system-test/src/systemTest/java/org/apache/mesos/elasticsearch/systemtest/SearchProxySystemTest.java
@@ -76,7 +76,7 @@ public class SearchProxySystemTest extends TestBase {
         AtomicInteger evaluatedHosts = new AtomicInteger(0);
         tasks.stream().forEach(task -> {
             try {
-                final HttpResponse<JsonNode> response = Unirest.get(searchEndpoint).queryString("q", "love").header("X-ElasticSearch-TaskId", task.getString("id")).asJson();
+                final HttpResponse<JsonNode> response = Unirest.get(searchEndpoint).queryString("q", "love").queryString("node", task.getString("id")).asJson();
                 assertEquals(200, response.getStatus());
                 assertFalse(response.getBody().getObject().getBoolean("timed_out"));
                 assertEquals(10, response.getBody().getObject().getJSONObject("hits").getJSONArray("hits").length());


### PR DESCRIPTION
Request:
`http://172.17.0.44:31100/v1/es/_search?q=test`

Response:
`{"timestamp":1442417064997,"status":500,"error":"Internal Server Error","exception":"java.util.NoSuchElementException","message":"No value present","path":"/v1/es/_search"}`

Context:
This only occurs if user selects other slave than `slave0`