### PR TITLE
Executor IPAddress discovery. Executor will now send IP address over …

### DIFF
--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -11,4 +11,6 @@ task taskCopyFilesForDocker(type: Copy) {
 
 dependencies {
     compile "com.beust:jcommander:1.48"
+    compile 'commons-lang:commons-lang:2.6'
+    compile "log4j:log4j:1.2.16"
 }

--- a/commons/src/main/java/org/apache/mesos/elasticsearch/common/AdaptorIPAddress.java
+++ b/commons/src/main/java/org/apache/mesos/elasticsearch/common/AdaptorIPAddress.java
@@ -1,0 +1,31 @@
+package org.apache.mesos.elasticsearch.common;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Obtains the first IP address from an adaptor
+ */
+public class AdaptorIPAddress {
+    private static final org.apache.log4j.Logger LOGGER = org.apache.log4j.Logger.getLogger(AdaptorIPAddress.class);
+    /**
+     * @return an InetAddress for the adaptor eth0 or en0 (so unit tests work on mac)
+     * @throws SocketException if adaptor doesn't exist or it doesn't have an IP Address
+     */
+    public static InetAddress eth0() throws SocketException {
+        Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
+        ArrayList<NetworkInterface> netList = Collections.list(nets);
+        LOGGER.debug(netList.stream().map(NetworkInterface::getName).collect(Collectors.joining(", ")));
+        NetworkInterface eth0 = netList.stream().filter(s -> s.getName().matches("eth0|en0")).findFirst().get();
+        ArrayList<InetAddress> inetAddresses = Collections.list(eth0.getInetAddresses());
+        Optional<InetAddress> address = inetAddresses.stream().filter(inetAddress -> inetAddress.getHostAddress().matches("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")).findFirst();
+        LOGGER.debug(eth0.getDisplayName() + ": " + address.get().getHostAddress());
+        return address.get();
+    }
+}

--- a/commons/src/main/java/org/apache/mesos/elasticsearch/common/SerializableIPAddress.java
+++ b/commons/src/main/java/org/apache/mesos/elasticsearch/common/SerializableIPAddress.java
@@ -1,0 +1,55 @@
+package org.apache.mesos.elasticsearch.common;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * IP address to be sent over a mesos framework message
+ */
+public class SerializableIPAddress implements Serializable {
+    public InetAddress getAddress() {
+        return address;
+    }
+
+    private final InetAddress address;
+
+    public SerializableIPAddress(InetAddress address) {
+        this.address = address;
+    }
+
+    public byte[] toBytes() {
+        return address.getAddress();
+    }
+
+    public static SerializableIPAddress fromBytes(byte[] data) throws UnknownHostException {
+        return new SerializableIPAddress(InetAddress.getByAddress(data));
+    }
+
+    @Override
+    public String toString() {
+        return address.getHostAddress();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37).
+                append(address).
+                toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+
+        SerializableIPAddress inetAddress = (SerializableIPAddress) obj;
+        return this.getAddress().equals(inetAddress.getAddress());
+    }
+}

--- a/commons/src/main/resources/log4j.xml
+++ b/commons/src/main/resources/log4j.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%p] %d %c %M - %m%n"/>
+        </layout>
+    </appender>
+
+    <logger name="org.apache.mesos.elasticsearch">
+        <level value="DEBUG"/>
+    </logger>
+
+    <root>
+        <level value="WARN"/>
+        <appender-ref ref="console" />
+    </root>
+
+</log4j:configuration>

--- a/commons/src/test/java/org/apache/mesos/elasticsearch/common/AdaptorIPAddressTest.java
+++ b/commons/src/test/java/org/apache/mesos/elasticsearch/common/AdaptorIPAddressTest.java
@@ -1,0 +1,19 @@
+package org.apache.mesos.elasticsearch.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author philwinder
+ * @since 21/10/2015
+ */
+public class AdaptorIPAddressTest {
+
+    @Test
+    public void testEth0() throws Exception {
+        assertNotNull(AdaptorIPAddress.eth0());
+        assertTrue(AdaptorIPAddress.eth0().getHostAddress().contains("."));
+        assertFalse(AdaptorIPAddress.eth0().getHostAddress().contains(":"));
+    }
+}

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
@@ -5,8 +5,10 @@ import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.elasticsearch.common.SerializableIPAddress;
 import org.apache.mesos.elasticsearch.scheduler.state.*;
 
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -124,6 +126,17 @@ public class ElasticsearchScheduler implements Scheduler {
     @Override
     public void frameworkMessage(SchedulerDriver driver, Protos.ExecutorID executorId, Protos.SlaveID slaveId, byte[] data) {
         LOGGER.info("Framework Message - Executor: " + executorId.getValue() + ", SlaveID: " + slaveId.getValue());
+        try {
+            SerializableIPAddress serializableIPAddress = SerializableIPAddress.fromBytes(data);
+            Protos.TaskInfo oldTask = clusterState.getTask(executorId);
+            Protos.TaskInfo newTask = Protos.TaskInfo.newBuilder().mergeFrom(oldTask)
+                    .setData(taskInfoFactory.toData(serializableIPAddress.getAddress().getHostName(), serializableIPAddress.getAddress().getHostAddress(), new Clock().zonedNow()))
+                    .build();
+            clusterState.removeTask(oldTask);
+            clusterState.addTask(newTask);
+        } catch (UnknownHostException e) {
+            LOGGER.warn("Unable to parse ip address discovery information");
+        }
     }
 
     @Override

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
@@ -64,7 +64,7 @@ public class TaskInfoFactory {
 
         return Protos.TaskInfo.newBuilder()
                 .setName(configuration.getTaskName())
-                .setData(toData(offer.getHostname(), new InetSocketAddress(offer.getHostname(), 1).getAddress().getHostAddress(), clock.zonedNow()))
+                .setData(toData(offer.getHostname(), "UNKNOWN", clock.zonedNow()))
                 .setTaskId(Protos.TaskID.newBuilder().setValue(taskId(offer)))
                 .setSlaveId(offer.getSlaveId())
                 .addAllResources(acceptedResources)
@@ -72,7 +72,7 @@ public class TaskInfoFactory {
                 .setExecutor(newExecutorInfo(configuration)).build();
     }
 
-    private ByteString toData(String hostname, String ipAddress, ZonedDateTime zonedDateTime) {
+    public ByteString toData(String hostname, String ipAddress, ZonedDateTime zonedDateTime) {
         Properties data = new Properties();
         data.put("hostname", hostname);
         data.put("ipAddress", ipAddress);


### PR DESCRIPTION
…Mesos framework message. It uses the eth0 adaptor to get the IP address, and only returns a valid ip4 address. If it cannot, then it will except. The v1/tasks endpoints may not be valid whilst the ip addresses are being sent.