### PR TITLE
ElasticsearchSchedulerTest fails because schedulerDriver is instantiated instead of mocked

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
@@ -1,7 +1,6 @@
 package org.apache.mesos.elasticsearch.scheduler;
 
 import org.apache.log4j.Logger;
-import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
@@ -22,7 +21,6 @@ public class ElasticsearchScheduler implements Scheduler {
 
     private final Configuration configuration;
     private final TaskInfoFactory taskInfoFactory;
-    private final CredentialFactory credentialFactory;
     private final ClusterState clusterState;
     private FrameworkState frameworkState;
     private OfferStrategy offerStrategy;
@@ -35,7 +33,6 @@ public class ElasticsearchScheduler implements Scheduler {
         this.taskInfoFactory = taskInfoFactory;
         this.offerStrategy = offerStrategy;
         this.zookeeperStateDriver = zookeeperStateDriver;
-        this.credentialFactory = new CredentialFactory(configuration);
     }
 
     public Map<String, Task> getTasks() {
@@ -46,24 +43,13 @@ public class ElasticsearchScheduler implements Scheduler {
         }
     }
 
-    public void run() {
+    public void run(SchedulerDriver schedulerDriver) {
         LOGGER.info("Starting ElasticSearch on Mesos - [numHwNodes: " + configuration.getElasticsearchNodes() +
                 ", zk mesos: " + configuration.getMesosZKURL() +
                 ", zk framework: " + configuration.getFrameworkZKURL() +
                 ", ram:" + configuration.getMem() + "]");
 
-        FrameworkInfoFactory frameworkInfoFactory = new FrameworkInfoFactory(configuration, frameworkState);
-        final Protos.FrameworkInfo.Builder frameworkBuilder = frameworkInfoFactory.getBuilder();
-        final Protos.Credential.Builder credentialBuilder = credentialFactory.getBuilder();
-        final MesosSchedulerDriver driver;
-        if (credentialBuilder.isInitialized()) {
-            LOGGER.debug("Creating Scheduler driver with principal: " + credentialBuilder.toString());
-            driver = new MesosSchedulerDriver(this, frameworkBuilder.build(), configuration.getMesosZKURL(), credentialBuilder.build());
-        } else {
-            driver = new MesosSchedulerDriver(this, frameworkBuilder.build(), configuration.getMesosZKURL());
-        }
-
-        driver.run();
+        schedulerDriver.run();
     }
 
     @Override

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Main.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Main.java
@@ -1,5 +1,8 @@
 package org.apache.mesos.elasticsearch.scheduler;
 
+import org.apache.log4j.Logger;
+import org.apache.mesos.MesosSchedulerDriver;
+import org.apache.mesos.Protos;
 import org.apache.mesos.elasticsearch.scheduler.cluster.ClusterMonitor;
 import org.apache.mesos.elasticsearch.scheduler.state.ClusterState;
 import org.apache.mesos.elasticsearch.scheduler.state.FrameworkState;
@@ -15,6 +18,8 @@ import java.util.concurrent.TimeUnit;
  * Application which starts the Elasticsearch scheduler
  */
 public class Main {
+    private static final Logger LOGGER = Logger.getLogger(Main.class);
+
     private final Environment env;
     private Configuration configuration;
 
@@ -57,9 +62,20 @@ public class Main {
                 clusterState,
                 taskInfoFactory,
                 new OfferStrategy(configuration, clusterState),
-                zookeeperStateDriver
-        );
+                zookeeperStateDriver);
         new ClusterMonitor(configuration, frameworkState, zookeeperStateDriver, scheduler);
+
+
+        FrameworkInfoFactory frameworkInfoFactory = new FrameworkInfoFactory(configuration, frameworkState);
+        final Protos.FrameworkInfo.Builder frameworkBuilder = frameworkInfoFactory.getBuilder();
+        final Protos.Credential.Builder credentialBuilder = new CredentialFactory(configuration).getBuilder();
+        final MesosSchedulerDriver schedulerDriver;
+        if (credentialBuilder.isInitialized()) {
+            LOGGER.debug("Creating Scheduler driver with principal: " + credentialBuilder.toString());
+            schedulerDriver = new MesosSchedulerDriver(scheduler, frameworkBuilder.build(), configuration.getMesosZKURL(), credentialBuilder.build());
+        } else {
+            schedulerDriver = new MesosSchedulerDriver(scheduler, frameworkBuilder.build(), configuration.getMesosZKURL());
+        }
 
         HashMap<String, Object> properties = new HashMap<>();
         properties.put("server.port", String.valueOf(configuration.getWebUiPort()));
@@ -70,7 +86,7 @@ public class Main {
                 .showBanner(false)
                 .run(args);
 
-        scheduler.run();
+        scheduler.run(schedulerDriver);
     }
 
     private void checkEnv() {

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchSchedulerTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchSchedulerTest.java
@@ -31,7 +31,7 @@ public class ElasticsearchSchedulerTest {
 
     private ElasticsearchScheduler scheduler;
 
-    private SchedulerDriver driver;
+    private SchedulerDriver driver = mock(SchedulerDriver.class);
 
     private Protos.FrameworkID frameworkID = Protos.FrameworkID.newBuilder().setValue(UUID.randomUUID().toString()).build();
 
@@ -64,10 +64,14 @@ public class ElasticsearchSchedulerTest {
 
         scheduler = new ElasticsearchScheduler(configuration, frameworkState, clusterState, taskInfoFactory, offerStrategy, serializableState);
 
-        driver = mock(SchedulerDriver.class);
-
         masterInfo = newMasterInfo();
         scheduler.registered(driver, frameworkID, masterInfo);
+    }
+
+    @Test
+    public void willRunDriver() throws Exception {
+        scheduler.run(driver);
+        verify(driver).run();
     }
 
     @Test
@@ -125,19 +129,6 @@ public class ElasticsearchSchedulerTest {
         scheduler.resourceOffers(driver, singletonList(offer));
 
         verify(driver).launchTasks(singleton(offer.getId()), singleton(taskInfo));
-    }
-
-    @Test
-    public void shouldRunWithCredentials() {
-        when(configuration.getFrameworkPrincipal()).thenReturn("user1");
-        when(configuration.getFrameworkSecretPath()).thenReturn("/etc/passwd");
-        try {
-            scheduler.run();
-        } catch (java.lang.UnsatisfiedLinkError e) {
-            LOGGER.info("This error is normal. Don't worry.");
-        }
-        verify(configuration, atLeastOnce()).getFrameworkPrincipal();
-        verify(configuration, atLeastOnce()).getFrameworkSecretPath();
     }
 
     private Protos.Offer.Builder newOffer(String hostname) {


### PR DESCRIPTION
The test expects the ElasticsearchScheduler to use the mocked SchedulerDriver but inside the run() method is is instantiated

```
    public void run() {
        LOGGER.info("Starting ElasticSearch on Mesos - [numHwNodes: " + configuration.getElasticsearchNodes() +
                ", zk mesos: " + configuration.getMesosZKURL() +
                ", zk framework: " + configuration.getFrameworkZKURL() +
                ", ram:" + configuration.getMem() + "]");

        FrameworkInfoFactory frameworkInfoFactory = new FrameworkInfoFactory(configuration, frameworkState);
        final Protos.FrameworkInfo.Builder frameworkBuilder = frameworkInfoFactory.getBuilder();
        final Protos.Credential.Builder credentialBuilder = credentialFactory.getBuilder();
        final MesosSchedulerDriver driver;
        if (credentialBuilder.isInitialized()) {
            LOGGER.debug("Creating Scheduler driver with principal: " + credentialBuilder.toString());
            driver = new MesosSchedulerDriver(this, frameworkBuilder.build(), configuration.getMesosZKURL(), credentialBuilder.build());
        } else {
            driver = new MesosSchedulerDriver(this, frameworkBuilder.build(), configuration.getMesosZKURL());
        }

        driver.run();
    }
```

The test fails with the following message because it tries to connect to ZK instead of using a mock SchedulerDriver.

```
    [DEBUG] 2015-10-15 11:55:20,540 org.apache.mesos.elasticsearch.scheduler.FrameworkInfoFactory setFrameworkPrincipal - Using framework principal: user1
    [DEBUG] 2015-10-15 11:55:20,552 class org.apache.mesos.elasticsearch.scheduler.ElasticsearchScheduler run - Creating Scheduler driver with principal: org.apache.mesos.Protos$Credential$Builder@6d0896c1
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1015 11:55:20.592780 29850 sched.cpp:1323] 
**************************************************
Scheduler driver bound to loopback interface! Cannot communicate with remote master(s). You might want to set 'LIBPROCESS_IP' environment variable to use a routable IP address.
**************************************************
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@log_env@712: Client environment:zookeeper.version=zookeeper C client 3.4.5
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@log_env@716: Client environment:host.name=franktop
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@log_env@723: Client environment:os.name=Linux
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@log_env@724: Client environment:os.arch=3.19.0-28-generic
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@log_env@725: Client environment:os.version=#30-Ubuntu SMP Mon Aug 31 15:52:51 UTC 2015
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@log_env@733: Client environment:user.name=(null)
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@log_env@741: Client environment:user.home=/home/frank
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@log_env@753: Client environment:user.dir=/home/frank/src/mesos-elasticsearch/scheduler
2015-10-15 11:55:20,593:29815(0x7f25e17fa700):ZOO_INFO@zookeeper_init@786: Initiating client connection, host=zookeeper:2181 sessionTimeout=10000 watcher=0x7f25ea8eaf30 sessionId=0 sessionPasswd=<null> context=0x7f2590003270 flags=0
I1015 11:55:20.593814 29850 sched.cpp:157] Version: 0.22.0
2015-10-15 11:55:20,698:29815(0x7f25e17fa700):ZOO_ERROR@getaddrs@599: getaddrinfo: No such file or directory

F1015 11:55:20.698626 29860 zookeeper.cpp:113] Failed to create ZooKeeper, zookeeper_init: No such file or directory [2]
*** Check failure stack trace: ***
    @     0x7f25eab98dfd  google::LogMessage::Fail()
    @     0x7f25eab9ac3d  google::LogMessage::SendToLog()
    @     0x7f25eab989ec  google::LogMessage::Flush()
    @     0x7f25eab98bf9  google::LogMessage::~LogMessage()
    @     0x7f25eab99b62  google::ErrnoLogMessage::~ErrnoLogMessage()
    @     0x7f25ea8eb8d1  ZooKeeperProcess::initialize()
    @     0x7f25eab468d1  process::ProcessManager::resume()
    @     0x7f25eab46b3c  process::schedule()
    @     0x7f260ae496aa  start_thread
    @     0x7f260b585eed  (unknown)
:scheduler:test FAILED
```