### PR TITLE
Build incompatible with Docker 1.8+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.DockerTagImage
 
 ext {
-    mesosVer = "0.22.1"
+    mesosVer = "0.25.0"
     elasticsearchVersion="1.7.1"
     imagePrefix = 'mesos'
     springBootVersion = "1.2.5.RELEASE"

--- a/commons/Dockerfile
+++ b/commons/Dockerfile
@@ -9,5 +9,5 @@ RUN echo "deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main" > /etc/
 RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   apt-get -y update && \
-  apt-get -y install mesos=0.22.1-1.0.ubuntu1404 && \
+  apt-get -y install mesos=0.25.0-0.2.70.ubuntu1404 && \
   rm -rf /var/lib/apt/lists/*

--- a/system-test/build.gradle
+++ b/system-test/build.gradle
@@ -20,14 +20,14 @@ dependencies {
     compile 'com.github.docker-java:docker-java:1.3.0'
     compile 'com.mashape.unirest:unirest-java:1.4.5'
     compile 'com.jayway.awaitility:awaitility:1.6.3'
-    compile 'com.github.ContainerSolutions:mini-mesos:bb53e37569'
+    compile 'com.github.ContainerSolutions:minimesos:a53e783f88'
 
     systemTestCompile project(':scheduler')
     systemTestCompile 'junit:junit:4.12'
     systemTestCompile 'com.github.docker-java:docker-java:1.3.0'
     systemTestCompile 'com.mashape.unirest:unirest-java:1.4.5'
     systemTestCompile 'com.jayway.awaitility:awaitility:1.6.3'
-    systemTestCompile 'com.github.ContainerSolutions:mini-mesos:bb53e37569'
+    systemTestCompile 'com.github.ContainerSolutions:minimesos:a53e783f88'
 }
 
 task main(type:JavaExec, dependsOn: 'compileJava') {

--- a/system-test/src/main/java/org/apache/mesos/elasticsearch/systemtest/ElasticsearchSchedulerContainer.java
+++ b/system-test/src/main/java/org/apache/mesos/elasticsearch/systemtest/ElasticsearchSchedulerContainer.java
@@ -5,6 +5,8 @@ import com.containersol.minimesos.container.AbstractContainer;
 import com.containersol.minimesos.mesos.MesosSlave;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.elasticsearch.common.cli.ElasticsearchCLIParameter;
 import org.apache.mesos.elasticsearch.common.cli.ZookeeperCLIParameter;
@@ -21,7 +23,7 @@ import java.util.List;
 public class ElasticsearchSchedulerContainer extends AbstractContainer {
 
     private static final org.apache.mesos.elasticsearch.systemtest.Configuration TEST_CONFIG = new org.apache.mesos.elasticsearch.systemtest.Configuration();
-    public static final String DOCKER0_ADAPTOR_IP_ADDRESS = "172.17.42.1";
+    protected final String DOCKER0_ADAPTOR_IP_ADDRESS;
 
     private final String zkIp;
 
@@ -40,6 +42,8 @@ public class ElasticsearchSchedulerContainer extends AbstractContainer {
         this.zkIp = zkIp;
         this.frameworkRole = frameworkRole;
         this.cluster = cluster;
+
+        DOCKER0_ADAPTOR_IP_ADDRESS = dockerClient.versionCmd().exec().getVersion().startsWith("1.9.") ? "172.17.0.1" : "172.17.42.1";
     }
 
     @Override

--- a/system-test/src/main/java/org/apache/mesos/elasticsearch/systemtest/Main.java
+++ b/system-test/src/main/java/org/apache/mesos/elasticsearch/systemtest/Main.java
@@ -14,7 +14,7 @@ public class Main {
 
     public static final Logger LOGGER = Logger.getLogger(Main.class);
     public static final Configuration TEST_CONFIG = new Configuration();
-    public static final String MESOS_IMAGE_TAG = "0.22.1-1.0.ubuntu1404";
+    public static final String MESOS_IMAGE_TAG = "0.25.0-0.2.70.ubuntu1404";
 
     public static void main(String[] args) throws InterruptedException {
         MesosCluster cluster = new MesosCluster(

--- a/system-test/src/systemTest/java/org/apache/mesos/elasticsearch/systemtest/DataVolumesSystemTest.java
+++ b/system-test/src/systemTest/java/org/apache/mesos/elasticsearch/systemtest/DataVolumesSystemTest.java
@@ -7,7 +7,6 @@ import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import com.jayway.awaitility.Awaitility;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.apache.mesos.elasticsearch.scheduler.Configuration;
@@ -19,8 +18,6 @@ import java.io.InputStream;
 import java.security.SecureRandom;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests data volumes


### PR DESCRIPTION
Mesos 22.1 is incompatible with 1.8: https://issues.apache.org/jira/browse/INFRA-10621

To build with an older version of docker, use:
```
export FUSION_BOOT2DOCKER_URL=https://github.com/boot2docker/boot2docker/releases/download/v1.7.1/boot2docker.iso
docker-machine create --driver=vmwarefusion mesos-es
```

Blocked on #338