### PR TITLE
Executor processes are not allocated any resources

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
@@ -24,6 +24,8 @@ public class Configuration {
     public static final String ELASTICSEARCH_CPU = "--elasticsearchCpu";
     public static final String ELASTICSEARCH_RAM = "--elasticsearchRam";
     public static final String ELASTICSEARCH_DISK = "--elasticsearchDisk";
+    public static final String ELASTICSEARCH_EXECUTOR_CPU = "--elasticsearchExecutorCpu";
+    public static final String ELASTICSEARCH_EXECUTOR_RAM =  "--elasticsearchExecutorRam";
     // **** WEB UI
     public static final String WEB_UI_PORT = "--webUiPort";
     public static final String FRAMEWORK_NAME = "--frameworkName";
@@ -55,6 +57,10 @@ public class Configuration {
     private double mem = 256;
     @Parameter(names = {ELASTICSEARCH_DISK}, description = "The amount of Disk resource to allocate to the elasticsearch instance (MB).", validateValueWith = CLIValidators.PositiveDouble.class)
     private double disk = 1024;
+    @Parameter(names = {ELASTICSEARCH_EXECUTOR_CPU}, description = "The amount of CPU resource to allocate to the elasticsearch executor.", validateValueWith = CLIValidators.PositiveDouble.class)
+    private double executorCpus = 0.1;
+    @Parameter(names = {ELASTICSEARCH_EXECUTOR_RAM}, description = "The amount of ram resource to allocate to the elasticsearch executor (MB).", validateValueWith = CLIValidators.PositiveDouble.class)
+    private double executorMem = 32;
     @Parameter(names = {WEB_UI_PORT}, description = "TCP port for web ui interface.", validateValueWith = CLIValidators.PositiveInteger.class)
     private int webUiPort = 31100; // Default is more likely to work on a default Mesos installation
     // **** FRAMEWORK
@@ -113,6 +119,14 @@ public class Configuration {
 
     public double getDisk() {
         return disk;
+    }
+
+    public double getExecutorCpus() {
+        return executorCpus;
+    }
+
+    public double getExecutorMem() {
+        return executorMem;
     }
 
     public int getElasticsearchNodes() {

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Resources.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Resources.java
@@ -76,8 +76,8 @@ public class Resources {
     }
 
     public static ArrayList<Protos.Resource> buildFrameworkResources(Configuration configuration) {
-        Protos.Resource cpus = Resources.cpus(configuration.getCpus(), configuration.getFrameworkRole());
-        Protos.Resource mem = Resources.mem(configuration.getMem(), configuration.getFrameworkRole());
+        Protos.Resource cpus = Resources.cpus(configuration.getCpus() - configuration.getExecutorCpus(), configuration.getFrameworkRole());
+        Protos.Resource mem = Resources.mem(configuration.getMem() - configuration.getExecutorMem(), configuration.getFrameworkRole());
         Protos.Resource disk = Resources.disk(configuration.getDisk(), configuration.getFrameworkRole());
         return new ArrayList<>(Arrays.asList(cpus, mem, disk));
     }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
@@ -114,7 +114,10 @@ public class TaskInfoFactory {
                     .setDocker(containerBuilder)
                     .addVolumes(Protos.Volume.newBuilder().setHostPath(SETTINGS_PATH_VOLUME).setContainerPath(SETTINGS_PATH_VOLUME).setMode(Protos.Volume.Mode.RO)) // Temporary fix until we get a data container.
                     .addVolumes(Protos.Volume.newBuilder().setContainerPath(SETTINGS_DATA_VOLUME_CONTAINER).setHostPath(configuration.getDataDir()).setMode(Protos.Volume.Mode.RW).build())
-                    .build());
+                    .build())
+                    .addResources(Resources.cpus(configuration.getExecutorCpus(), configuration.getFrameworkRole()))
+                    .addResources(Resources.mem(configuration.getExecutorMem(), configuration.getFrameworkRole()))
+            ;
         }
         return executorInfoBuilder;
     }


### PR DESCRIPTION
Although we allocate resources to ES, we don't allocate resources to the executors. This results in a warning message.

However, we have to be careful, because users often specify ES CPUs in whole numbers. For example: User specifies ES CPU = 1.0. In the code we can give the executors 0.1 CPU. Now we require an offer of 1.1, even though to the user it looks like they are only requesting 1.0.