### PR TITLE
410 - Sanity check framework registered

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Main.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Main.java
@@ -83,6 +83,7 @@ public class Main {
                 .properties(properties)
                 .initializers(applicationContext -> applicationContext.getBeanFactory().registerSingleton("scheduler", scheduler))
                 .initializers(applicationContext -> applicationContext.getBeanFactory().registerSingleton("configuration", configuration))
+                .initializers(applicationContext -> applicationContext.getBeanFactory().registerSingleton("frameworkState", frameworkState))
                 .showBanner(false)
                 .run(args);
 

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/controllers/TasksController.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/controllers/TasksController.java
@@ -3,12 +3,14 @@ package org.apache.mesos.elasticsearch.scheduler.controllers;
 import org.apache.mesos.elasticsearch.scheduler.Configuration;
 import org.apache.mesos.elasticsearch.scheduler.ElasticsearchScheduler;
 import org.apache.mesos.elasticsearch.scheduler.Task;
+import org.apache.mesos.elasticsearch.scheduler.state.FrameworkState;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.InetSocketAddress;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,10 +30,16 @@ public class TasksController {
     @Autowired
     Configuration configuration;
 
+    @Autowired
+    FrameworkState frameworkState;
+
     @RequestMapping
     public List<GetTasksResponse> getTasks() {
-        return scheduler.getTasks().entrySet().stream().map(this::from).collect(toList());
-
+        if (frameworkState.isRegistered()) {
+            return scheduler.getTasks().entrySet().stream().map(this::from).collect(toList());
+        } else {
+            return new ArrayList<>(0);
+        }
     }
 
     private GetTasksResponse from(Map.Entry<String, Task> task) {

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/controllers/TasksControllerTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/controllers/TasksControllerTest.java
@@ -1,0 +1,33 @@
+package org.apache.mesos.elasticsearch.scheduler.controllers;
+
+import org.apache.mesos.elasticsearch.scheduler.state.FrameworkState;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = TestConfiguration.class)
+public class TasksControllerTest {
+
+    @Autowired
+    TasksController controller;
+
+    @Autowired
+    FrameworkState frameworkState;
+
+    @Test
+    public void shouldNotCrashWhenFrameworkNotRegistered() {
+        Mockito.when(frameworkState.isRegistered()).thenReturn(false);
+        List<TasksController.GetTasksResponse> tasks = controller.getTasks();
+        assertTrue(tasks.isEmpty());
+    }
+}

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/controllers/TestConfiguration.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/controllers/TestConfiguration.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.http.client.HttpClient;
 import org.apache.mesos.elasticsearch.common.cli.ZookeeperCLIParameter;
 import org.apache.mesos.elasticsearch.scheduler.ElasticsearchScheduler;
+import org.apache.mesos.elasticsearch.scheduler.state.FrameworkState;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -42,4 +43,7 @@ public class TestConfiguration {
     public HttpClient getMockHttpClient() {
         return Mockito.mock(HttpClient.class);
     }
+
+    @Bean
+    public FrameworkState getMockFrameworkState() { return Mockito.mock(FrameworkState.class); }
 }


### PR DESCRIPTION
Sanity check framework registered before getting tasks to prevent UI thread stack trace. Fixes #410.