### PR TITLE
Avoid taking privileged ports

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategy.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategy.java
@@ -23,7 +23,7 @@ public class OfferStrategy {
             new OfferRule("Host already running task", this::isHostAlreadyRunningTask),
             new OfferRule("Hostname is unresolveable", offer -> !isHostnameResolveable(offer.getHostname())),
             new OfferRule("Cluster size already fulfilled", offer -> clusterState.getTaskList().size() >= configuration.getElasticsearchNodes()),
-            new OfferRule("Offer did not have 2 ports", offer -> !containsTwoPorts(offer.getResourcesList())),
+            new OfferRule("Offer did not have 2 unprivileged ports", offer -> !containsTwoUnprivilegedPorts(offer.getResourcesList())),
             new OfferRule("Offer did not have enough CPU resources", offer -> !isEnoughCPU(configuration, offer.getResourcesList())),
             new OfferRule("Offer did not have enough RAM resources", offer -> !isEnoughRAM(configuration, offer.getResourcesList())),
             new OfferRule("Offer did not have enough disk resources", offer -> !isEnoughDisk(configuration, offer.getResourcesList()))
@@ -93,8 +93,8 @@ public class OfferStrategy {
         return new ResourceCheck(Resources.RESOURCE_MEM).isEnough(resourcesList, configuration.getMem());
     }
 
-    private boolean containsTwoPorts(List<Protos.Resource> resources) {
-        return Resources.selectTwoPortsFromRange(resources).size() == 2;
+    private boolean containsTwoUnprivilegedPorts(List<Protos.Resource> resources) {
+        return Resources.selectTwoUnprivilegedPortsFromRange(resources).size() == 2;
     }
 
     /**

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
@@ -47,7 +47,7 @@ public class TaskInfoFactory {
      */
     public Protos.TaskInfo createTask(Configuration configuration, FrameworkState frameworkState, Protos.Offer offer) {
         this.frameworkState = frameworkState;
-        List<Integer> ports = Resources.selectTwoPortsFromRange(offer.getResourcesList());
+        List<Integer> ports = Resources.selectTwoUnprivilegedPortsFromRange(offer.getResourcesList());
 
         List<Protos.Resource> acceptedResources = Resources.buildFrameworkResources(configuration);
 


### PR DESCRIPTION
Usually ports less than 1024 are reserved for other purposes. More specifically we (at the mesos/logstash) rely on being offered port 514 for receiving syslog. So if Elasticsearch is being started before logstash, ES will reserve port 514 and ultimately prevent logstash from being started.