### PR TITLE
New Feature: Adds support for External Volumes

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
@@ -52,6 +52,9 @@ public class Configuration {
     public static final String JAVA_HOME = "--javaHome";
     public static final String USE_IP_ADDRESS = "--useIpAddress";
     public static final String ELASTICSEARCH_PORTS = "--elasticsearchPorts";
+    // **** External Volumes
+    public static final String EXTERNAL_VOLUME_DRIVER = "--externalVolumeDriver";
+    public static final String EXTERNAL_VOLUME_OPTIONS = "--externalVolumeOptions";
 
     @Parameter(names = {EXECUTOR_HEALTH_DELAY}, description = "The delay between executor healthcheck requests (ms).", validateValueWith = CLIValidators.PositiveLong.class)
     private static Long executorHealthDelay = 30000L;
@@ -104,6 +107,12 @@ public class Configuration {
     private String javaHome = "";
     @Parameter(names = {USE_IP_ADDRESS}, arity = 1, description = "If true, the framework will resolve the local ip address. If false, it uses the hostname.")
     private Boolean isUseIpAddress = false;
+    
+    // **** External Volumes
+    @Parameter(names = {EXTERNAL_VOLUME_DRIVER}, description = "This defines the use of an external storage drivers to be used. By default, elastic serch nodes will not be created with external volumes but rather direct attached storage.")
+    private String externalVolumeDriver = "";
+    @Parameter(names = {EXTERNAL_VOLUME_OPTIONS}, description = "This describes how volumes are to be created.")
+    private String externalVolumeOption = "";
 
     // ****************** Runtime configuration **********************
     public Configuration(String... args) {
@@ -274,6 +283,14 @@ public class Configuration {
             portsList.add(Integer.parseInt(port));
         }
         return portsList;
+    }
+    
+    public String getExternalVolumeDriver() {
+        return externalVolumeDriver;
+    }
+    
+    public String getExternalVolumeOption() {
+        return externalVolumeOption;
     }
 
     /**

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Main.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Main.java
@@ -56,7 +56,7 @@ public class Main {
                 frameworkState,
                 clusterState,
                 taskInfoFactory,
-                new OfferStrategy(configuration, clusterState),
+                configuration.getExternalVolumeDriver() != null && configuration.getExternalVolumeDriver().length() > 0 ? new OfferStrategyExternalStorage(configuration, clusterState) : new OfferStrategyNormal(configuration, clusterState),
                 zookeeperStateDriver);
         new ClusterMonitor(configuration, frameworkState, zookeeperStateDriver, scheduler);
 

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategy.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategy.java
@@ -14,30 +14,20 @@ import static java.util.Arrays.asList;
  * Offer strategy
  */
 public class OfferStrategy {
-    private static final Logger LOGGER = Logger.getLogger(ElasticsearchScheduler.class.toString());
+    protected static final Logger LOGGER = Logger.getLogger(ElasticsearchScheduler.class.toString());
     public static final int DUMMY_PORT = 80;
-    private ClusterState clusterState;
-    private Configuration configuration;
+    protected ClusterState clusterState;
+    protected Configuration configuration;
 
-    private List<OfferRule> acceptanceRules = asList(
-            new OfferRule("Host already running task", this::isHostAlreadyRunningTask),
-            new OfferRule("Hostname is unresolveable", offer -> !isHostnameResolveable(offer.getHostname())),
-            new OfferRule("First ES node is not responding", offer -> !isAtLeastOneESNodeRunning()),
-            new OfferRule("Cluster size already fulfilled", offer -> clusterState.getTaskList().size() >= configuration.getElasticsearchNodes()),
-            new OfferRule("Offer did not have 2 ports", offer -> !containsTwoPorts(offer.getResourcesList())),
-            new OfferRule("The offer does not contain the user specified ports", offer -> !containsUserSpecifiedPorts(offer.getResourcesList())),
-            new OfferRule("Offer did not have enough CPU resources", offer -> !isEnoughCPU(configuration, offer.getResourcesList())),
-            new OfferRule("Offer did not have enough RAM resources", offer -> !isEnoughRAM(configuration, offer.getResourcesList())),
-            new OfferRule("Offer did not have enough disk resources", offer -> !isEnoughDisk(configuration, offer.getResourcesList()))
-    );
+    protected List<OfferRule> acceptanceRules = null;
 
-    private boolean isHostnameResolveable(String hostname) {
+    protected boolean isHostnameResolveable(String hostname) {
         LOGGER.debug("Attempting to resolve hostname: " + hostname);
         InetSocketAddress address = new InetSocketAddress(hostname, DUMMY_PORT);
         return !address.isUnresolved();
     }
 
-    private boolean isAtLeastOneESNodeRunning() {
+    protected boolean isAtLeastOneESNodeRunning() {
         // If this is the first, do not check
         List<Protos.TaskInfo> taskList = clusterState.getTaskList();
         if (taskList.size() == 0) {
@@ -47,12 +37,12 @@ public class OfferStrategy {
         }
     }
 
-    public OfferStrategy(Configuration configuration, ClusterState clusterState) {
+    protected OfferStrategy(Configuration configuration, ClusterState clusterState) {
         this.clusterState = clusterState;
         this.configuration = configuration;
     }
 
-    public OfferResult evaluate(Protos.Offer offer) {
+    protected OfferResult evaluate(Protos.Offer offer) {
         final Optional<OfferRule> decline = acceptanceRules.stream().filter(offerRule -> offerRule.rule.accepts(offer)).limit(1).findFirst();
         if (decline.isPresent()) {
             return OfferResult.decline(decline.get().declineReason);
@@ -65,7 +55,7 @@ public class OfferStrategy {
     /**
      * Offer result
      */
-    public static class OfferResult {
+    protected static class OfferResult {
         final boolean acceptable;
         final Optional<String> reason;
 
@@ -83,7 +73,7 @@ public class OfferStrategy {
         }
     }
 
-    private boolean isHostAlreadyRunningTask(Protos.Offer offer) {
+    protected boolean isHostAlreadyRunningTask(Protos.Offer offer) {
         Boolean result = false;
         List<Protos.TaskInfo> stateList = clusterState.getTaskList();
         for (Protos.TaskInfo t : stateList) {
@@ -93,23 +83,20 @@ public class OfferStrategy {
         }
         return result;
     }
-    private boolean isEnoughDisk(Configuration configuration, List<Protos.Resource> resourcesList) {
-        return new ResourceCheck(Resources.RESOURCE_DISK).isEnough(resourcesList, configuration.getDisk());
-    }
 
-    private boolean isEnoughCPU(Configuration configuration, List<Protos.Resource> resourcesList) {
+    protected boolean isEnoughCPU(Configuration configuration, List<Protos.Resource> resourcesList) {
         return new ResourceCheck(Resources.RESOURCE_CPUS).isEnough(resourcesList, configuration.getCpus());
     }
 
-    private boolean isEnoughRAM(Configuration configuration, List<Protos.Resource> resourcesList) {
+    protected boolean isEnoughRAM(Configuration configuration, List<Protos.Resource> resourcesList) {
         return new ResourceCheck(Resources.RESOURCE_MEM).isEnough(resourcesList, configuration.getMem());
     }
 
-    private boolean containsTwoPorts(List<Protos.Resource> resources) {
+    protected boolean containsTwoPorts(List<Protos.Resource> resources) {
         return Resources.selectTwoPortsFromRange(resources).size() == 2;
     }
 
-    private boolean containsUserSpecifiedPorts(List<Protos.Resource> resourcesList) {
+    protected boolean containsUserSpecifiedPorts(List<Protos.Resource> resourcesList) {
         // If there are user specified ports, check each port is contained within the offer
         if (!configuration.getElasticsearchPorts().isEmpty()) {
             for (Integer port : configuration.getElasticsearchPorts()) {
@@ -124,7 +111,7 @@ public class OfferStrategy {
     /**
      * Rule and reason container object
      */
-    private static class OfferRule {
+    protected static class OfferRule {
         String declineReason;
         Rule rule;
 
@@ -138,7 +125,7 @@ public class OfferStrategy {
      * Interface for checking offers
      */
     @FunctionalInterface
-    private interface Rule {
+    protected interface Rule {
         boolean accepts(Protos.Offer offer);
     }
 }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategyExternalStorage.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategyExternalStorage.java
@@ -1,0 +1,34 @@
+package org.apache.mesos.elasticsearch.scheduler;
+
+import org.apache.log4j.Logger;
+import org.apache.mesos.Protos;
+import org.apache.mesos.elasticsearch.scheduler.state.ClusterState;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Offer strategy when external storage is involved. Notice when compared to the OfferStrategyNormal, the OfferRule for
+ * checking if enough storage space is no longer needed because external volumes size is managed externally (storage array, Amazon EBS, etc).
+ */
+public class OfferStrategyExternalStorage extends OfferStrategy {
+
+    public OfferStrategyExternalStorage(Configuration configuration, ClusterState clusterState) {
+        super(configuration, clusterState);
+        
+        acceptanceRules = asList(
+                new OfferRule("Host already running task", this::isHostAlreadyRunningTask),
+                new OfferRule("Hostname is unresolveable", offer -> !isHostnameResolveable(offer.getHostname())),
+                new OfferRule("First ES node is not responding", offer -> !isAtLeastOneESNodeRunning()),
+                new OfferRule("Cluster size already fulfilled", offer -> clusterState.getTaskList().size() >= configuration.getElasticsearchNodes()),
+                new OfferRule("Offer did not have 2 ports", offer -> !containsTwoPorts(offer.getResourcesList())),
+                new OfferRule("The offer does not contain the user specified ports", offer -> !containsUserSpecifiedPorts(offer.getResourcesList())),
+                new OfferRule("Offer did not have enough CPU resources", offer -> !isEnoughCPU(configuration, offer.getResourcesList())),
+                new OfferRule("Offer did not have enough RAM resources", offer -> !isEnoughRAM(configuration, offer.getResourcesList()))
+        );
+    }
+
+}

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategyNormal.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategyNormal.java
@@ -1,0 +1,38 @@
+package org.apache.mesos.elasticsearch.scheduler;
+
+import org.apache.log4j.Logger;
+import org.apache.mesos.Protos;
+import org.apache.mesos.elasticsearch.scheduler.state.ClusterState;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Offer strategy
+ */
+public class OfferStrategyNormal extends OfferStrategy {
+
+    public OfferStrategyNormal(Configuration configuration, ClusterState clusterState) {
+        super(configuration, clusterState);
+        
+        acceptanceRules = asList(
+                new OfferRule("Host already running task", this::isHostAlreadyRunningTask),
+                new OfferRule("Hostname is unresolveable", offer -> !isHostnameResolveable(offer.getHostname())),
+                new OfferRule("First ES node is not responding", offer -> !isAtLeastOneESNodeRunning()),
+                new OfferRule("Cluster size already fulfilled", offer -> clusterState.getTaskList().size() >= configuration.getElasticsearchNodes()),
+                new OfferRule("Offer did not have 2 ports", offer -> !containsTwoPorts(offer.getResourcesList())),
+                new OfferRule("The offer does not contain the user specified ports", offer -> !containsUserSpecifiedPorts(offer.getResourcesList())),
+                new OfferRule("Offer did not have enough CPU resources", offer -> !isEnoughCPU(configuration, offer.getResourcesList())),
+                new OfferRule("Offer did not have enough RAM resources", offer -> !isEnoughRAM(configuration, offer.getResourcesList())),
+                new OfferRule("Offer did not have enough disk resources", offer -> !isEnoughDisk(configuration, offer.getResourcesList()))
+        );
+    }
+
+    private boolean isEnoughDisk(Configuration configuration, List<Protos.Resource> resourcesList) {
+        return new ResourceCheck(Resources.RESOURCE_DISK).isEnough(resourcesList, configuration.getDisk());
+    }
+
+}

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Resources.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Resources.java
@@ -78,6 +78,12 @@ public class Resources {
         Protos.Resource cpus = Resources.cpus(configuration.getCpus() - configuration.getExecutorCpus(), configuration.getFrameworkRole());
         Protos.Resource mem = Resources.mem(configuration.getMem() - configuration.getExecutorMem(), configuration.getFrameworkRole());
         Protos.Resource disk = Resources.disk(configuration.getDisk(), configuration.getFrameworkRole());
+        
+        //if we are using external storage, then we dont need to take disk into account
+        if (configuration.getExternalVolumeDriver() != null && configuration.getExternalVolumeDriver().length() > 0) {
+            return new ArrayList<>(Arrays.asList(cpus, mem));
+        }
+        
         return new ArrayList<>(Arrays.asList(cpus, mem, disk));
     }
 

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
@@ -12,7 +12,16 @@ import java.util.List;
 public class ExecutorEnvironmentalVariables {
     private static final String native_mesos_library_key = "MESOS_NATIVE_JAVA_LIBRARY";
     private static final String native_mesos_library_path = "/usr/lib/libmesos.so"; // libmesos.so is usually symlinked to the version.
+    
     public static final String JAVA_OPTS = "JAVA_OPTS";
+    public static final int EXTERNAL_VOLUME_NOT_CONFIGURED = -1;
+    public static final String ELASTICSEARCH_NODE_ID = "ELASTICSEARCH_NODE_ID";
+    
+    public static final String DVDI_VOLUME_NAME              = "DVDI_VOLUME_NAME";
+    public static final String DVDI_VOLUME_DRIVER            = "DVDI_VOLUME_DRIVER";
+    public static final String DVDI_VOLUME_OPTS              = "DVDI_VOLUME_OPTS";
+    public static final String DVDI_VOLUME_CONTAINERPATH     = "DVDI_VOLUME_CONTAINERPATH";
+    
     private final List<Protos.Environment.Variable> envList = new ArrayList<>();
 
     /**
@@ -20,6 +29,18 @@ public class ExecutorEnvironmentalVariables {
      */
     public ExecutorEnvironmentalVariables(Configuration configuration) {
         populateEnvMap(configuration);
+    }
+    public ExecutorEnvironmentalVariables(Configuration configuration, long lNodeId) {
+        populateEnvMap(configuration);
+        
+        if (lNodeId != EXTERNAL_VOLUME_NOT_CONFIGURED) {
+            return; //invalid node id
+        }
+        
+        addToList(ELASTICSEARCH_NODE_ID, Long.toString(lNodeId));
+        
+        //uses the mesos isolator to create/attach external volumes by setting env variables
+        populateEnvMapForMesos(configuration, lNodeId);
     }
 
     /**
@@ -39,6 +60,41 @@ public class ExecutorEnvironmentalVariables {
             addToList(native_mesos_library_key, native_mesos_library_path);
         }
         addToList(JAVA_OPTS, getHeapSpaceString(configuration));
+    }
+     
+    private void populateEnvMapForMesos(Configuration configuration, long lNodeId) {
+        if (configuration.isFrameworkUseDocker() ||
+                configuration.getExternalVolumeDriver() == null ||
+                configuration.getExternalVolumeDriver().length() == 0) {
+            return; //volume driver not set
+        }
+        
+        //note: this makes a unique configuration volume name per elastic search node
+        StringBuffer sbConfig = new StringBuffer(configuration.getFrameworkName());
+        sbConfig.append(Long.toString(lNodeId));
+        sbConfig.append("config");
+        
+        //note: this makes a unique data volume name per elastic search node
+        StringBuffer sbData = new StringBuffer(configuration.getFrameworkName());
+        sbData.append(Long.toString(lNodeId));
+        sbData.append("data");
+        
+        //sets the environment variables for to create and/or attach the configuration volume
+        //to the mesos containerizer
+        addToList(DVDI_VOLUME_DRIVER, configuration.getExternalVolumeDriver());
+        addToList(DVDI_VOLUME_NAME, sbConfig.toString());
+        if (configuration.getExternalVolumeOption() != null && configuration.getExternalVolumeOption().length() > 0) {
+            addToList(DVDI_VOLUME_OPTS, configuration.getExternalVolumeOption());
+        }
+        
+        //sets the environment variables for to create and/or attach the data volume
+        //to the mesos containerizer
+        addToList(DVDI_VOLUME_DRIVER + "1", configuration.getExternalVolumeDriver());
+        addToList(DVDI_VOLUME_NAME + "1", sbData.toString());
+        if (configuration.getExternalVolumeOption() != null && configuration.getExternalVolumeOption().length() > 0) {
+            addToList(DVDI_VOLUME_OPTS + "1", configuration.getExternalVolumeOption());
+        }
+
     }
 
     private void addToList(String key, String value) {

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchSchedulerTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchSchedulerTest.java
@@ -44,7 +44,7 @@ public class ElasticsearchSchedulerTest {
 
     private org.apache.mesos.elasticsearch.scheduler.Configuration configuration;
     private SerializableState serializableState = mock(SerializableState.class);
-    private OfferStrategy offerStrategy = mock(OfferStrategy.class);
+    private OfferStrategyNormal offerStrategy = mock(OfferStrategyNormal.class);
 
     @Before
     public void before() {

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategyTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategyTest.java
@@ -35,7 +35,7 @@ public class OfferStrategyTest {
     ClusterState clusterState;
 
     @InjectMocks
-    OfferStrategy offerStrategy;
+    OfferStrategyNormal offerStrategy;
 
     @Before
     public void setUp() throws Exception {
@@ -49,7 +49,7 @@ public class OfferStrategyTest {
     public void willDeclineIfHostIsAlreadyRunningTask() throws Exception {
         when(clusterState.getTaskList()).thenReturn(singletonList(createTask("host1")));
 
-        final OfferStrategy.OfferResult result = offerStrategy.evaluate(validOffer("host1"));
+        final OfferStrategyNormal.OfferResult result = offerStrategy.evaluate(validOffer("host1"));
         assertFalse(result.acceptable);
         assertEquals("Host already running task", result.reason.get());
     }
@@ -59,7 +59,7 @@ public class OfferStrategyTest {
         when(clusterState.getTaskList()).thenReturn(asList(createTask("host1"), createTask("host2"), createTask("host3")));
         when(configuration.getElasticsearchNodes()).thenReturn(3);
 
-        final OfferStrategy.OfferResult result = offerStrategy.evaluate(validOffer("host4"));
+        final OfferStrategyNormal.OfferResult result = offerStrategy.evaluate(validOffer("host4"));
         assertFalse(result.acceptable);
         assertEquals("Cluster size already fulfilled", result.reason.get());
     }
@@ -69,7 +69,7 @@ public class OfferStrategyTest {
         when(clusterState.getTaskList()).thenReturn(asList(createTask("host1"), createTask("host2")));
         when(configuration.getElasticsearchNodes()).thenReturn(3);
 
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(9200, 9200, configuration.getFrameworkRole()))
                 .build());
         assertFalse(offerResult.acceptable);
@@ -82,7 +82,7 @@ public class OfferStrategyTest {
         when(configuration.getElasticsearchNodes()).thenReturn(3);
         when(configuration.getElasticsearchPorts()).thenReturn(Arrays.asList(9200, 9300));
 
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(31000, 32000, configuration.getFrameworkRole()))
                 .build());
         assertFalse(offerResult.acceptable);
@@ -95,7 +95,7 @@ public class OfferStrategyTest {
         when(configuration.getElasticsearchNodes()).thenReturn(3);
         when(configuration.getElasticsearchPorts()).thenReturn(Arrays.asList(31000, 9300));
 
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(31000, 32000, configuration.getFrameworkRole()))
                 .build());
         assertFalse(offerResult.acceptable);
@@ -108,7 +108,7 @@ public class OfferStrategyTest {
         when(configuration.getElasticsearchNodes()).thenReturn(3);
         when(configuration.getElasticsearchPorts()).thenReturn(Arrays.asList(9200, 9300));
 
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(31000, 32000, configuration.getFrameworkRole()))
                 .addResources(portRange(9200, 9300, configuration.getFrameworkRole()))
                 .addResources(cpus(configuration.getCpus(), configuration.getFrameworkRole()))
@@ -124,7 +124,7 @@ public class OfferStrategyTest {
         when(configuration.getElasticsearchNodes()).thenReturn(3);
         when(configuration.getCpus()).thenReturn(1.0);
 
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(9200, 9200, configuration.getFrameworkRole()))
                 .addResources(portRange(9300, 9300, configuration.getFrameworkRole()))
                 .addResources(cpus(0.1, configuration.getFrameworkRole()))
@@ -138,7 +138,7 @@ public class OfferStrategyTest {
         when(configuration.getElasticsearchNodes()).thenReturn(3);
         when(configuration.getMem()).thenReturn(100.0);
 
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(9200, 9200, configuration.getFrameworkRole()))
                 .addResources(portRange(9300, 9300, configuration.getFrameworkRole()))
                 .addResources(cpus(10.0, configuration.getFrameworkRole()))
@@ -154,7 +154,7 @@ public class OfferStrategyTest {
         when(configuration.getElasticsearchNodes()).thenReturn(3);
         when(configuration.getDisk()).thenReturn(100.0);
 
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(9200, 9200, configuration.getFrameworkRole()))
                 .addResources(portRange(9300, 9300, configuration.getFrameworkRole()))
                 .addResources(cpus(10.0, configuration.getFrameworkRole()))
@@ -170,7 +170,7 @@ public class OfferStrategyTest {
         when(clusterState.getTaskList()).thenReturn(asList(createTask("host1"), createTask("host2")));
         when(configuration.getElasticsearchNodes()).thenReturn(3);
 
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(9200, 9200, configuration.getFrameworkRole()))
                 .addResources(portRange(9300, 9300, configuration.getFrameworkRole()))
                 .addResources(cpus(configuration.getCpus(), configuration.getFrameworkRole()))
@@ -185,7 +185,7 @@ public class OfferStrategyTest {
     public void shouldDeclineWhenHostIsUnresolveable() throws InvalidProtocolBufferException {
         when(clusterState.getTaskList()).thenReturn(asList(createTask("host1"), createTask("host2")));
         when(configuration.getElasticsearchNodes()).thenReturn(3);
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(9200, 9200, configuration.getFrameworkRole()))
                 .addResources(portRange(9300, 9300, configuration.getFrameworkRole()))
                 .addResources(cpus(configuration.getCpus(), configuration.getFrameworkRole()))
@@ -200,7 +200,7 @@ public class OfferStrategyTest {
     public void shouldAcceptWhenHostIsResolveable() throws InvalidProtocolBufferException {
         when(clusterState.getTaskList()).thenReturn(asList(createTask("host1"), createTask("host2")));
         when(configuration.getElasticsearchNodes()).thenReturn(3);
-        final OfferStrategy.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
+        final OfferStrategyNormal.OfferResult offerResult = offerStrategy.evaluate(baseOfferBuilder("host3")
                 .addResources(portRange(9200, 9200, configuration.getFrameworkRole()))
                 .addResources(portRange(9300, 9300, configuration.getFrameworkRole()))
                 .addResources(cpus(configuration.getCpus(), configuration.getFrameworkRole()))


### PR DESCRIPTION
Adds support for External Volumes to be used for both the config and data volumes for elastic search nodes. This support works for both Docker and Mesos containerizers.

This functionality works by assigning an elasticsearch node id to each node that is created. That node id metadata is saved in the form of an environment variable that can be accessed later on. When a node fails (crash or health check fails) for this example lets say node 2, that task is released thereby releasing the node id back into the pool. When the new task is launched to replace the failed node, the node id 2 will be free and the new task will assume the id of the old node perhaps on a completely different mesos agent and it will reattach the volumes and continue where it left off. This should yield a much quicker rebuild of the elastic search node since it isn't rebuilding from scratch.

In the Docker container case (default), the use of external volumes has been solved generically and it will enable all Docker Volume Drivers. In TaskInfoFactory.java on line 134, we add the docker run parameter "volume-driver" which enables the external support. You will also noticed that when "volume-driver" is set, the hostpath no longer references a path on the host node but rather the external volume name.

In the Mesos container case, the use of external volumes has be implemented using mesos isolator modules like the mesos-module-dvdi module. Example: github.com/emccode/mesos-module-dvdi You can find the environment variable interface specification there.

Also it is worth noting that the original OfferStrategy class has been made into a parent class. The class OfferStrategyNormal extends OfferStrategy and provides the exact same strategy that the original OfferStrategy provided. The new class OfferStrategyExternalStorage is enabled when an external storage driver is specified and removes the storage/disk checks from the strategy because the volumes are externally managed now.
