### PR TITLE
SIGTERM will gracefully shutdown the framework.

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/ElasticsearchScheduler.java
@@ -164,4 +164,10 @@ public class ElasticsearchScheduler implements Scheduler {
     public void error(SchedulerDriver driver, String message) {
         LOGGER.error("Error: " + message);
     }
+
+    public void shutdown(SchedulerDriver driver) {
+        clusterState.getTaskList().stream().forEach(taskInfo -> driver.killTask(taskInfo.getTaskId())); // Kill tasks.
+        clusterState.destroy(); // Remove tasks from zk
+        frameworkState.destroy(); // Remove framework state from zk.
+    }
 }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Main.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Main.java
@@ -69,6 +69,14 @@ public class Main {
             schedulerDriver = new MesosSchedulerDriver(scheduler, frameworkBuilder.build(), configuration.getMesosZKURL());
         }
 
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                LOGGER.info("Performing graceful shutdown");
+                scheduler.shutdown(schedulerDriver);
+            }
+        });
+
         HashMap<String, Object> properties = new HashMap<>();
         properties.put("server.port", String.valueOf(configuration.getWebUiPort()));
         new SpringApplicationBuilder(WebApplication.class)

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/ClusterState.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/ClusterState.java
@@ -154,6 +154,21 @@ public class ClusterState {
     }
 
     /**
+     * Deletes all tasks and state.
+     */
+    public void destroy() {
+        try {
+            getTaskList().stream().forEach(taskInfo -> getStatus(taskInfo).destroy());
+            // Todo (pnw): Refactor. This shouldn't be mopping up the ESTaskStatus stuff
+            zooKeeperStateDriver.delete(getKey());
+            zooKeeperStateDriver.delete(frameworkState.getFrameworkID().getValue() + "/" + ESTaskStatus.STATE_KEY);
+            zooKeeperStateDriver.delete(frameworkState.getFrameworkID().getValue());
+        } catch (IOException e) {
+            LOGGER.error("Unable to delete state from ZooKeeper", e);
+        }
+    }
+
+    /**
      * Updates a task with the given status. Status is written to zookeeper.
      * If the task is in error, then the healthchecks are stopped and state is removed from ZK
      * @param status A received task status

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/ESTaskStatus.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/ESTaskStatus.java
@@ -14,6 +14,7 @@ import java.security.InvalidParameterException;
  * the respective TaskStatus packet.
  */
 public class ESTaskStatus {
+    // Todo (pnw): Refactor: This is part of the cluster state, but is often accessed without cluster state.
     private static final Logger LOGGER = Logger.getLogger(TaskStatus.class);
     public static final String STATE_KEY = "state";
     public static final String DEFAULT_STATUS_NO_MESSAGE_SET = "Default status. No message set.";

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/FrameworkState.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/FrameworkState.java
@@ -65,7 +65,7 @@ public class FrameworkState {
         try {
             statePath.rm(FRAMEWORKID_KEY);
         } catch (IOException e) {
-            LOGGER.error("Unable to delete framework ID from zookeeper", e);
+            LOGGER.error("Unable to delete " + FRAMEWORKID_KEY + " from zookeeper", e);
         }
     }
 

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/FrameworkState.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/FrameworkState.java
@@ -61,6 +61,14 @@ public class FrameworkState {
         registeredListeners.forEach(listener -> listener.accept(clusterState));
     }
 
+    public void destroy() {
+        try {
+            statePath.rm(FRAMEWORKID_KEY);
+        } catch (IOException e) {
+            LOGGER.error("Unable to delete framework ID from zookeeper", e);
+        }
+    }
+
     public SchedulerDriver getDriver() {
         return driver;
     }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/StatePath.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/StatePath.java
@@ -43,4 +43,9 @@ public class StatePath {
         }
         return exists;
     }
+
+    public void rm(String key) throws IOException {
+        key = key.replace(" ", "");
+        zkState.delete(key);
+    }
 }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/StatePath.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/state/StatePath.java
@@ -1,7 +1,5 @@
 package org.apache.mesos.elasticsearch.scheduler.state;
 
-import org.apache.log4j.Logger;
-
 import java.io.IOException;
 import java.security.InvalidParameterException;
 
@@ -9,7 +7,6 @@ import java.security.InvalidParameterException;
  * Path utilities
  */
 public class StatePath {
-    private static final Logger LOGGER = Logger.getLogger(StatePath.class);
     private SerializableState zkState;
     public StatePath(SerializableState zkState) {
         this.zkState = zkState;
@@ -44,8 +41,13 @@ public class StatePath {
         return exists;
     }
 
+    /**
+     * Remove a zNode or zFolder.
+     *
+     * @param key the path to remove.
+     * @throws IOException If unable to remove
+     */
     public void rm(String key) throws IOException {
-        key = key.replace(" ", "");
         zkState.delete(key);
     }
 }

--- a/scheduler/start-scheduler.sh
+++ b/scheduler/start-scheduler.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java $JAVA_OPTS -Djava.library.path=/usr/lib -jar /tmp/elasticsearch-mesos-scheduler.jar "$@"
+exec java $JAVA_OPTS -Djava.library.path=/usr/lib -jar /tmp/elasticsearch-mesos-scheduler.jar "$@"


### PR DESCRIPTION
All executors will be killed.
Zk state is removed.

To test:
```
$ docker kill --signal=SIGTERM ${SCHEDULER_ID}
$ docker exec -it ${ZOOKEEPER_ID} bash
# ./bin/zkCli.sh
[zk: localhost:2181(CONNECTED) 1] ls /elasticsearch/mesos-ha
[]
```
Confirm no zk nodes.
Fixes #462 