### PR TITLE
Write ES data to cluster-name and slaveID specific folders

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -252,6 +252,13 @@ It is strongly recommended that you use the containerized version of Mesos Elast
 
 Jars are available under the (releases section of github)[https://github.com/mesos/elasticsearch/releases].
 
+### Data directory
+The ES node data can be written to a specific directory. If in docker mode, use the `--dataDir` option. If in jar mode, set the `path.data` option in your custom ES settings file.
+
+The cluster name and slaveID will be appended to the end of the data directory option. This allows users with a shared network drive to write node specific data to their own seperate location.
+
+For example, if the user specifies a data directory of `/var/lib/data`, then the data for the agent with a Slave ID of S1 will be written to `/var/lib/data/mesos-ha/S1`.
+
 ### User Interface
 
 The web based user interface is available on port 31100 of the scheduler by default. It displays real time information about the tasks running in the cluster and a basic configuration overview of the cluster. 

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
@@ -285,7 +285,7 @@ public class Configuration {
                 + "\" nobody";
     }
 
-    public List<String> esArguments(ClusterState clusterState, Protos.DiscoveryInfo discoveryInfo) {
+    public List<String> esArguments(ClusterState clusterState, Protos.DiscoveryInfo discoveryInfo, Protos.SlaveID slaveID) {
         List<String> args = new ArrayList<>();
         List<Protos.TaskInfo> taskList = clusterState.getTaskList();
         String hostAddress = "";
@@ -305,8 +305,9 @@ public class Configuration {
         args.add("--default.index.number_of_replicas=0");
         args.add("--default.index.auto_expand_replicas=0-all");
         if (!isFrameworkUseDocker()) {
+            String taskSpecificDataDir = taskSpecificHostDir(slaveID);
             args.add("--path.home=" + HOST_PATH_HOME); // Cannot be overidden
-            args.add("--default.path.data=" + getDataDir());
+            args.add("--default.path.data=" + taskSpecificDataDir);
             args.add("--path.conf=" + HOST_PATH_CONF); // Cannot be overidden
         } else {
             args.add("--path.data=" + CONTAINER_PATH_DATA); // Cannot be overidden
@@ -325,6 +326,10 @@ public class Configuration {
 
 
         return args;
+    }
+
+    public String taskSpecificHostDir(Protos.SlaveID slaveID) {
+        return getDataDir() + "/" + getElasticsearchClusterName() + "/" + slaveID.getValue();
     }
 
     private void addIfNotEmpty(List<String> args, String key, String value) {

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ConfigurationTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ConfigurationTest.java
@@ -67,7 +67,8 @@ public class ConfigurationTest {
                 .addPorts(Protos.Port.newBuilder().setNumber(port)))
                 .setVisibility(Protos.DiscoveryInfo.Visibility.EXTERNAL)
                 .build();
-        final List<String> arguments = configuration.esArguments(clusterState, discoveryInfo);
+        Protos.SlaveID slaveID = Protos.SlaveID.newBuilder().setValue("SLAVE").build();
+        final List<String> arguments = configuration.esArguments(clusterState, discoveryInfo, slaveID);
         String allArgs = arguments.toString();
         assertTrue(allArgs.contains(Integer.toString(port)));
     }

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactoryTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactoryTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.*;
 public class TaskInfoFactoryTest {
 
     private static final double EPSILON = 0.0001;
+    public static final String SLAVEID = "SLAVEID";
 
     @Mock
     private FrameworkState frameworkState;
@@ -60,6 +61,7 @@ public class TaskInfoFactoryTest {
         when(configuration.getFrameworkRole()).thenReturn("some-framework-role");
         when(configuration.isFrameworkUseDocker()).thenReturn(true);
         when(configuration.getElasticsearchPorts()).thenReturn(Collections.emptyList());
+        when(configuration.taskSpecificHostDir(any())).thenReturn("/var/lib/mesos/slave/elasticsearch/cluster-name/" + SLAVEID);
     }
 
     @Test
@@ -99,7 +101,7 @@ public class TaskInfoFactoryTest {
 
         assertEquals(2, taskInfo.getContainer().getVolumesCount());
         assertEquals(Configuration.CONTAINER_PATH_DATA, taskInfo.getContainer().getVolumes(0).getContainerPath());
-        assertEquals(Configuration.DEFAULT_HOST_DATA_DIR, taskInfo.getContainer().getVolumes(0).getHostPath());
+        assertEquals(Configuration.DEFAULT_HOST_DATA_DIR + "/" + configuration.getElasticsearchClusterName() + "/" + offer.getSlaveId().getValue(), taskInfo.getContainer().getVolumes(0).getHostPath());
         assertEquals(Protos.Volume.Mode.RW, taskInfo.getContainer().getVolumes(0).getMode());
         assertEquals(Configuration.CONTAINER_PATH_CONF, taskInfo.getContainer().getVolumes(1).getContainerPath());
         assertEquals(Configuration.HOST_PATH_CONF, taskInfo.getContainer().getVolumes(1).getHostPath());
@@ -117,7 +119,7 @@ public class TaskInfoFactoryTest {
     private Protos.Offer getOffer(Protos.FrameworkID frameworkId) {
         return Protos.Offer.newBuilder()
                                                 .setId(Protos.OfferID.newBuilder().setValue(UUID.randomUUID().toString()))
-                                                .setSlaveId(Protos.SlaveID.newBuilder().setValue(UUID.randomUUID().toString()))
+                .setSlaveId(Protos.SlaveID.newBuilder().setValue(SLAVEID))
                                                 .setFrameworkId(frameworkId)
                                                 .setHostname("localhost")
                                                 .addAllResources(asList(

--- a/system-test/src/systemTest/java/org/apache/mesos/elasticsearch/systemtest/DataVolumesSystemTest.java
+++ b/system-test/src/systemTest/java/org/apache/mesos/elasticsearch/systemtest/DataVolumesSystemTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -93,9 +94,9 @@ public class DataVolumesSystemTest extends TestBase {
                     .withAttachStderr()
                     .exec();
             try (InputStream inputstream = CLUSTER_ARCHITECTURE.dockerClient.execStartCmd(containerId).withTty().withExecId(execResponse.getId()).exec()) {
-                String contents = IOUtils.toString(inputstream, "UTF-8");
-                LOGGER.info("Mesos-local contents of " + dataDirectory + ": " + contents);
-                return contents.contains("0") && contents.contains("1") && contents.contains("2");
+                String contents = IOUtils.toString(inputstream, Charset.defaultCharset()).replaceAll("\\p{C}", "");
+                LOGGER.info("Contents of " + dataDirectory + ": " + contents);
+                return contents.contains("S0") && contents.contains("S1") && contents.contains("S2");
             } catch (IOException e) {
                 LOGGER.error("Could not list contents of " + dataDirectory + " in Mesos-Local");
                 return false;


### PR DESCRIPTION
Data is now written to a folder based upon the dataDir, but with the cluster name and slave ID appended. This allows shared network drives to have a folder specific to each node. E.g. if a node dies and recovers, it can re-read the network drive and get the correct folder.

Fixes #372 