### PR TITLE
Add name and protocol to discovery info packet.

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
@@ -67,7 +67,7 @@ public class TaskInfoFactory {
     private Protos.TaskInfo buildNativeTask(Protos.Offer offer, Configuration configuration, Clock clock, Long elasticSearchNodeId) {
         final List<Integer> ports = getPorts(offer, configuration);
         final List<Protos.Resource> resources = getResources(configuration, ports);
-        final Protos.DiscoveryInfo discovery = getDiscovery(ports);
+        final Protos.DiscoveryInfo discovery = getDiscovery(ports, configuration);
 
         final String hostAddress = resolveHostAddress(offer, ports);
 
@@ -89,7 +89,7 @@ public class TaskInfoFactory {
     private Protos.TaskInfo buildDockerTask(Protos.Offer offer, Configuration configuration, Clock clock, Long elasticSearchNodeId) {
         final List<Integer> ports = getPorts(offer, configuration);
         final List<Protos.Resource> resources = getResources(configuration, ports);
-        final Protos.DiscoveryInfo discovery = getDiscovery(ports);
+        final Protos.DiscoveryInfo discovery = getDiscovery(ports, configuration);
 
         final String hostAddress = resolveHostAddress(offer, ports);
 
@@ -135,13 +135,14 @@ public class TaskInfoFactory {
         return acceptedResources;
     }
 
-    private Protos.DiscoveryInfo getDiscovery(List<Integer> ports) {
+    private Protos.DiscoveryInfo getDiscovery(List<Integer> ports, Configuration configuration) {
         Protos.DiscoveryInfo.Builder discovery = Protos.DiscoveryInfo.newBuilder();
         Protos.Ports.Builder discoveryPorts = Protos.Ports.newBuilder();
-        discoveryPorts.addPorts(Discovery.CLIENT_PORT_INDEX, Protos.Port.newBuilder().setNumber(ports.get(0)).setName(Discovery.CLIENT_PORT_NAME));
-        discoveryPorts.addPorts(Discovery.TRANSPORT_PORT_INDEX, Protos.Port.newBuilder().setNumber(ports.get(1)).setName(Discovery.TRANSPORT_PORT_NAME));
+        discoveryPorts.addPorts(Discovery.CLIENT_PORT_INDEX, Protos.Port.newBuilder().setNumber(ports.get(0)).setName(Discovery.CLIENT_PORT_NAME).setProtocol("TCP"));
+        discoveryPorts.addPorts(Discovery.TRANSPORT_PORT_INDEX, Protos.Port.newBuilder().setNumber(ports.get(1)).setName(Discovery.TRANSPORT_PORT_NAME).setProtocol("TCP"));
         discovery.setPorts(discoveryPorts);
         discovery.setVisibility(Protos.DiscoveryInfo.Visibility.EXTERNAL);
+        discovery.setName(configuration.getTaskName());
         return discovery.build();
     }
 

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactoryTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactoryTest.java
@@ -51,7 +51,7 @@ public class TaskInfoFactoryTest {
     public void before() {
         Protos.FrameworkID frameworkId = Protos.FrameworkID.newBuilder().setValue(UUID.randomUUID().toString()).build();
         when(frameworkState.getFrameworkID()).thenReturn(frameworkId);
-        when(configuration.getTaskName()).thenReturn("esdemo");
+        when(configuration.getTaskName()).thenReturn(Configuration.EXECUTOR_NAME);
         when(configuration.getMesosZKURL()).thenReturn("zk://zookeeper:2181/mesos");
         when(configuration.getExecutorImage()).thenReturn(Configuration.DEFAULT_EXECUTOR_IMAGE);
         when(configuration.getElasticsearchSettingsLocation()).thenReturn(Configuration.HOST_PATH_CONF);


### PR DESCRIPTION
Fixed #480. Will now produced discovery info packets that look like:
```
discovery {
  visibility: EXTERNAL
  name: "--executorName"
  ports {
    ports {
      number: 9200
      name: "CLIENT_PORT"
      protocol: "TCP"
    }
    ports {
      number: 9300
      name: "TRANSPORT_PORT"
      protocol: "TCP"
    }
  }
}
```
Where "--executorName" is the value passed into the framework with the `--executorName` setting.