### PR TITLE
Mesos labels can be added to executor tasks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,9 @@ Usage: (Options preceded by an asterisk are required) [options]
     --executorName
        The name given to the executor task.
        Default: elasticsearch-executor
+    --executorLabels
+       One or more labels given to the executor task. Example: 'environment=prod bananas=apples'
+       Default: <empty string>
     --externalVolumeDriver
        This defines the use of an external storage drivers to be used. By
        default, elasticsearch nodes will not be created with external volumes but rather

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
@@ -19,6 +19,8 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -36,6 +38,7 @@ public class Configuration {
     public static final String WEB_UI_PORT = "--webUiPort";
     public static final String FRAMEWORK_NAME = "--frameworkName";
     public static final String EXECUTOR_NAME = "--executorName";
+    public static final String EXECUTOR_LABELS = "--executorLabels";
     public static final String DATA_DIR = "--dataDir";
     public static final String DEFAULT_HOST_DATA_DIR = "/var/lib/mesos/slave/elasticsearch";
     // DCOS Certification requirement 01
@@ -85,6 +88,9 @@ public class Configuration {
     private String frameworkName = "elasticsearch";
     @Parameter(names = {EXECUTOR_NAME}, description = "The name given to the executor task.", validateWith = CLIValidators.NotEmptyString.class)
     private String executorName = "elasticsearch-executor";
+    @Parameter(names = {EXECUTOR_LABELS}, description = "One or more labels given to the executor task." +
+        "E.g. 'environment=prod bananas=apples'", variableArity = true)
+    private List<String> executorLabels = new ArrayList<>();
     @Parameter(names = {DATA_DIR}, description = "The host data directory used by Docker volumes in the executors. [DOCKER MODE ONLY]")
     private String dataDir = DEFAULT_HOST_DATA_DIR;
     @Parameter(names = {FRAMEWORK_FAILOVER_TIMEOUT}, description = "The time before Mesos kills a scheduler and tasks if it has not recovered (ms).", validateValueWith = CLIValidators.PositiveDouble.class)
@@ -174,6 +180,18 @@ public class Configuration {
 
     public String getTaskName() {
         return executorName;
+    }
+
+    public Map<String, String> getTaskLabels() {
+        HashMap<String, String> map = new HashMap<>();
+        for (String keyValue : executorLabels) {
+            String[] kvp = keyValue.split("=", 2);
+            if (kvp.length == 2) {
+              map.put(kvp[0], kvp[1]);
+            }
+        }
+
+        return map;
     }
 
     public String getDataDir() {

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
@@ -19,6 +19,7 @@ import java.text.SimpleDateFormat;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -68,6 +69,7 @@ public class TaskInfoFactory {
         final List<Integer> ports = getPorts(offer, configuration);
         final List<Protos.Resource> resources = getResources(configuration, ports);
         final Protos.DiscoveryInfo discovery = getDiscovery(ports, configuration);
+        final Protos.Labels labels = getLabels(configuration);
 
         final String hostAddress = resolveHostAddress(offer, ports);
 
@@ -82,6 +84,7 @@ public class TaskInfoFactory {
                 .setSlaveId(offer.getSlaveId())
                 .addAllResources(resources)
                 .setDiscovery(discovery)
+                .setLabels(labels)
                 .setCommand(nativeCommand(configuration, args, elasticSearchNodeId))
                 .build();
     }
@@ -90,6 +93,7 @@ public class TaskInfoFactory {
         final List<Integer> ports = getPorts(offer, configuration);
         final List<Protos.Resource> resources = getResources(configuration, ports);
         final Protos.DiscoveryInfo discovery = getDiscovery(ports, configuration);
+        final Protos.Labels labels = getLabels(configuration);
 
         final String hostAddress = resolveHostAddress(offer, ports);
 
@@ -106,6 +110,7 @@ public class TaskInfoFactory {
                 .setSlaveId(offer.getSlaveId())
                 .addAllResources(resources)
                 .setDiscovery(discovery)
+                .setLabels(labels)
                 .setCommand(dockerCommand(configuration, args, elasticSearchNodeId))
                 .setContainer(containerInfo)
                 .build();
@@ -144,6 +149,21 @@ public class TaskInfoFactory {
         discovery.setVisibility(Protos.DiscoveryInfo.Visibility.EXTERNAL);
         discovery.setName(configuration.getTaskName());
         return discovery.build();
+    }
+
+    private Protos.Labels getLabels(Configuration configuration) {
+      Protos.Labels.Builder builder = Protos.Labels.newBuilder();
+      Map<String, String> labels = configuration.getTaskLabels();
+      for (Map.Entry<String, String> kvp : labels.entrySet()) {
+        Protos.Label label = Protos.Label.newBuilder()
+          .setKey(kvp.getKey())
+          .setValue(kvp.getValue())
+          .build();
+
+        builder.addLabels(label);
+      }
+
+      return builder.build();
     }
 
     private Protos.ContainerInfo getContainer(Configuration configuration, Protos.TaskID taskID, Long elasticSearchNodeId, Protos.SlaveID slaveID) {

--- a/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ConfigurationTest.java
+++ b/scheduler/src/test/java/org/apache/mesos/elasticsearch/scheduler/ConfigurationTest.java
@@ -11,6 +11,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -77,5 +78,21 @@ public class ConfigurationTest {
     public void shouldCreateVolumeName() {
         Configuration configuration = new Configuration(ZookeeperCLIParameter.ZOOKEEPER_MESOS_URL, "aa", Configuration.FRAMEWORK_NAME, "test");
         assertEquals("test0data", configuration.dataVolumeName(0L));
+    }
+
+    @Test
+    public void shouldCreateTaskLabels() {
+        Configuration configuration = new Configuration(
+            ZookeeperCLIParameter.ZOOKEEPER_MESOS_URL, "aa", Configuration.EXECUTOR_LABELS,
+              "foo=bar",
+              "incomplete",
+              "empty=",
+              "separator=values=are=joined");
+        Map<String, String> labels = configuration.getTaskLabels();
+
+        assertEquals("bar", labels.get("foo"));
+        assertFalse(labels.containsKey("incomplete"));
+        assertEquals("", labels.get("empty"));
+        assertEquals("values=are=joined", labels.get("separator"));
     }
 }


### PR DESCRIPTION
This commit enables operators to add additional meta-data to tasks launched by the ElasticSearch scheduler in the form of Mesos labels.
