### PR TITLE
New param executorNetworkPublishHost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.2] - [27 Mai 2016]
+
+### Bugfixes
+- [Network problem on DCOS - Executor elected the wrong interface for network_publish_host](https://github.com/mesos/elasticsearch/issues/565)
+
 ## [1.0.1] - [23 March 2016]
 
 ### Bugfixes

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,9 @@ Usage: (Options preceded by an asterisk are required) [options]
     --executorName
        The name given to the executor task.
        Default: elasticsearch-executor
+    --executorNetworkPublishHost
+       Option to change the executor network.publish.host parameter.
+       Default: _non_loopback:ipv4_
     --externalVolumeDriver
        Use external volume storage driver. By default, nodes will use volumes on
        host.

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
@@ -81,7 +81,7 @@ public class Configuration {
     private String elasticsearchPorts = ""; // Defaults to Mesos specified ports.
 
     // **** FRAMEWORK
-    private String version = "1.0.1";
+    private String version = "1.0.2";
     @Parameter(names = {FRAMEWORK_NAME}, description = "The name given to the framework.", validateWith = CLIValidators.NotEmptyString.class)
     private String frameworkName = "elasticsearch";
     @Parameter(names = {EXECUTOR_NAME}, description = "The name given to the executor task.", validateWith = CLIValidators.NotEmptyString.class)

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
@@ -46,6 +46,7 @@ public class Configuration {
     public static final String EXECUTOR_BINARY = "--elasticsearchBinaryUrl";
     public static final String DEFAULT_EXECUTOR_IMAGE = "elasticsearch:latest";
     public static final String EXECUTOR_FORCE_PULL_IMAGE = "--executorForcePullImage";
+    public static final String EXECUTOR_NETWORK_PUBLISH_HOST = "--executorNetworkPublishHost";
     public static final String FRAMEWORK_PRINCIPAL = "--frameworkPrincipal";
     public static final String FRAMEWORK_SECRET_PATH = "--frameworkSecretPath";
     public static final String ES_TAR = "public/elasticsearch.tar.gz";
@@ -98,6 +99,8 @@ public class Configuration {
     private String executorBinary = "";
     @Parameter(names = {EXECUTOR_FORCE_PULL_IMAGE}, arity = 1, description = "Option to force pull the executor image. [DOCKER MODE ONLY]")
     private Boolean executorForcePullImage = false;
+    @Parameter(names = {EXECUTOR_NETWORK_PUBLISH_HOST}, description = "Option to change the executor network.publish.host parameter.")
+    private String executorNetworkPublishHost = "_non_loopback:ipv4_";
     @Parameter(names = {FRAMEWORK_PRINCIPAL}, description = "The principal to use when registering the framework (username).")
     private String frameworkPrincipal = "";
     @Parameter(names = {FRAMEWORK_SECRET_PATH}, description = "The path to the file which contains the secret for the principal (password). Password in file must not have a newline.")
@@ -194,6 +197,10 @@ public class Configuration {
 
     public Boolean getExecutorForcePullImage() {
         return executorForcePullImage;
+    }
+    
+    public String getExecutorNetworkPublishHost() {
+        return executorNetworkPublishHost;
     }
 
     public Boolean getIsUseIpAddress() {
@@ -325,7 +332,7 @@ public class Configuration {
         }
         args.add("--default.bootstrap.mlockall=true");
         args.add("--default.network.bind_host=0.0.0.0");
-        args.add("--default.network.publish_host=_non_loopback:ipv4_");
+        args.add("--default.network.publish_host=" + getExecutorNetworkPublishHost());
         args.add("--default.gateway.recover_after_nodes=1");
         args.add("--default.gateway.expected_nodes=1");
         args.add("--default.indices.recovery.max_bytes_per_sec=100mb");

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
@@ -125,8 +125,7 @@ public class TaskInfoFactory {
         if (elasticsearchPorts.isEmpty() || elasticsearchPorts.stream().allMatch(port -> port == 0)) {
             //No ports requested by user or two random ports requested
             ports = Resources.selectTwoPortsFromRange(offer.getResourcesList());
-        }
-        else {
+        } else {
             //Replace a user requested port 0 with a random port
             ports = elasticsearchPorts.stream().map(port -> port != 0 ?  port : Resources.selectOnePortFromRange(offer.getResourcesList())).collect(Collectors.toList());
         }


### PR DESCRIPTION
I have found a problem on DC/OS where the executor has elected a wrong interface for the network.publish.host . Now I have added this arg as new parameter and  added as a new value in my updated version of your dcos-package.

The default value is again "_non_loopback:ipv4_". 

**Tested on:**
- DCOS
- DCOS-Docker
- Mesos native

Would be fine if anyone checks my code because I am not a coder.

**For testing on DC/OS:**
```sh
dcos package repo add universe-jstabenow https://github.com/jstabenow/dcos-packages/archive/version-2.x.zip
dcos package install elasticsearch
```

If wanted we can update your DC/OS package afterwards on Universe.