### PR TITLE
Allow subpaths in ZK URLs

### DIFF
--- a/commons/src/main/java/org/apache/mesos/elasticsearch/common/zookeeper/model/ZKAddress.java
+++ b/commons/src/main/java/org/apache/mesos/elasticsearch/common/zookeeper/model/ZKAddress.java
@@ -14,7 +14,7 @@ public class ZKAddress {
     public static final String ZK_PREFIX = "zk://";
     public static final String USER_AND_PASS_REG = "([^/@:]+):([^/@:]+)";
     public static final String HOST_AND_PORT_REG = "([A-z0-9-.]+)(?::)([0-9]+)";
-    public static final String ZK_NODE_REG = "/([^/]+)";
+    public static final String ZK_NODE_REG = "/([^/]+(?:/[^/]+)*)";
     public static final String ADDRESS_REGEX = "^(?:" + USER_AND_PASS_REG + "@)?" + HOST_AND_PORT_REG + "(?:" + ZK_NODE_REG + ")?";
     public static final String VALID_ZK_URL = "zk://host1:port1,user:pass@host2:port2/path,.../path";
     private String user;

--- a/commons/src/test/java/org/apache/mesos/elasticsearch/common/zookeeper/parser/ZKAddressParserTest.java
+++ b/commons/src/test/java/org/apache/mesos/elasticsearch/common/zookeeper/parser/ZKAddressParserTest.java
@@ -71,6 +71,30 @@ public class ZKAddressParserTest {
     }
 
     @Test
+    public void shouldAcceptIfSingleZKAddressWithSubpath() {
+        String add = "zk://192.168.0.1:2182/mesos/subpath";
+        List<ZKAddress> zk = new ZKAddressParser().validateZkUrl(add);
+        assertZKEquals(zk.get(0), "", "", "192.168.0.1", "2182", "mesos/subpath");
+    }
+
+    @Test
+    public void shouldAcceptIfMultiZKAddressWithSubpath() {
+        String add = "zk://192.168.0.1:2182,10.4.52.3:1234/mesos/sub_path";
+        List<ZKAddress> zk = new ZKAddressParser().validateZkUrl(add);
+        assertZKEquals(zk.get(0), "", "", "192.168.0.1", "2182", "");
+        assertZKEquals(zk.get(1), "", "", "10.4.52.3", "1234", "mesos/sub_path");
+    }
+
+    @Test
+    public void shouldAcceptIfMultiZKAddressWithMultiSubpath() {
+        String add = "zk://192.168.0.1:2182/mesos/sub_path1,10.4.52.3:1234/mesos/sub_path2";
+        List<ZKAddress> zk = new ZKAddressParser().validateZkUrl(add);
+        assertZKEquals(zk.get(0), "", "", "192.168.0.1", "2182", "mesos/sub_path1");
+        assertZKEquals(zk.get(1), "", "", "10.4.52.3", "1234", "mesos/sub_path2");
+    }
+
+
+    @Test
     public void shouldAcceptIfSpacesInPath() {
         String add = "zk://192.168.0.1:2182, 10.4.52.3:1234/mesos";
         List<ZKAddress> zk = new ZKAddressParser().validateZkUrl(add);


### PR DESCRIPTION
We have development mesos clusters that use the same ZK cluster but chrooted on different paths under `/mesos/{dev1,dev2,...}`. I tried to spin up the elasticsearch framework on one of these but got stopped by a `ZKAddressException`.

The reason is that the `ZK_NODE_REG` part of the full `ADDRESS_REGEX` that validates ZK URLs in `org.apache.mesos.elasticsearch.common.zookeeper.model.ZKAddress` only allows for one path segment beneath the root. I.e. `/mesos` and `/my_mesos_cluster` are valid, but `/mesos/cluster1` isn't.

This PR relaxes the `ZK_NODE_REG` regex a bit to allow for subpaths in the ZK URL. Commit   52ab30b adds a couple of tests that fail with the current regex, and 57084ed is the actual change to the regex which makes the tests pass.

Please let me know what you think! Thanks.
