### PR TITLE
Ack ElasticSearch 5.0 changes regarding heap size

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Environment.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Environment.java
@@ -7,6 +7,10 @@ import org.apache.mesos.elasticsearch.scheduler.configuration.ExecutorEnvironmen
  */
 public class Environment {
     public String getJavaHeap() {
-        return System.getenv().get(ExecutorEnvironmentalVariables.JAVA_OPTS);
+        String javaOpts = System.getenv().get(ExecutorEnvironmentalVariables.JAVA_OPTS);
+        if (javaOpts == null || javaOpts.isEmpty()) {
+            javaOpts = System.getenv().get(ExecutorEnvironmentalVariables.ES_JAVA_OPTS);
+        }
+        return javaOpts;
     }
 }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
@@ -68,7 +68,7 @@ public class ExecutorEnvironmentalVariables {
         if (configuration.isFrameworkUseDocker()) {
             addToList(native_mesos_library_key, native_mesos_library_path);
         }
-        addToList(ES_JAVA_OPTS, getHeapSpaceString(configuration));
+        addToList(ES_JAVA_OPTS, getHeapSpaceString(configuration, 192));
     }
 
     private void populateEnvMapForMesos(Configuration configuration, Long nodeId) {
@@ -112,5 +112,16 @@ public class ExecutorEnvironmentalVariables {
     private String getHeapSpaceString(Configuration configuration) {
         int osRam = (int) Math.min(256.0, configuration.getMem() / 4.0);
         return "" + ((int) configuration.getMem() - osRam) + "m";
+    }
+
+    /**
+     * Gets the heap space settings. Will set minimum heap space as 256, minimum or available/4, whichever is smaller. Max heap will be available space.
+     * @param configuration The mesos cluster configuration
+     * @param min The minimum heap space; used if smaller than 256 and smaller than available/4
+     * @return A string representing the java heap space.
+     */
+    private String getHeapSpaceString(Configuration configuration, int min) {
+        int osRam = (int) Math.min(256.0, min, configuration.getMem() / 4.0);
+        return "-Xms" + osRam + "m -Xmx"+ configuration.getMem() + "m";
     }
 }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
@@ -18,6 +18,7 @@ public class ExecutorEnvironmentalVariables {
     private static final String CONTAINER_PATH_SETTINGS = "/tmp/config";
     
     public static final String JAVA_OPTS = "JAVA_OPTS";
+    public static final String ES_JAVA_OPTS = "ES_JAVA_OPTS";
     public static final String ES_HEAP = "ES_HEAP_SIZE";
     public static final int EXTERNAL_VOLUME_NOT_CONFIGURED = -1;
     public static final String ELASTICSEARCH_NODE_ID = "ELASTICSEARCH_NODE_ID";
@@ -67,6 +68,7 @@ public class ExecutorEnvironmentalVariables {
         if (configuration.isFrameworkUseDocker()) {
             addToList(native_mesos_library_key, native_mesos_library_path);
         }
+        addToList(ES_JAVA_OPTS, getHeapSpaceString(configuration));
     }
 
     private void populateEnvMapForMesos(Configuration configuration, Long nodeId) {


### PR DESCRIPTION
The heap size in ElasticSearch 5.0 now come from the env var
"ES_JAVA_OPTS", as opposed to the old "JAVA_OPTS". This change strives
for better compatibility with other ElasticSearch versions, and acks
ES_JAVA_OPTS as one of the options of setting the heap size.