### PR TITLE
Mesos offer decline results in accept fix

### DIFF
--- a/commons/Dockerfile
+++ b/commons/Dockerfile
@@ -9,5 +9,5 @@ RUN echo "deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main" > /etc/
 RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   apt-get -y update && \
-  apt-get -y install mesos=0.25.0-0.2.70.ubuntu1404 && \
+  apt-get -y install mesos=0.26.0-0.2.145.ubuntu1404 && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
as mentioned in #575 there is a bug in Mesos 0.25.0 (which is used by the current docker image) which results in declined Mesos offers being accepted instead. Therefore Elasticsearch is eating up more offers then it actually needs. This was fixed in Mesos 0.26.0 (see https://issues.apache.org/jira/browse/MESOS-3522).

This PR makes the docker image use Mesos 0.26.0 which includes this fix. I tried to keep the version increase as minimal as possible. This PR was also verified on our cluster, which confirmed the issue being fixed.